### PR TITLE
Simplify logging

### DIFF
--- a/pg_diffix/utils.h
+++ b/pg_diffix/utils.h
@@ -7,18 +7,11 @@
 
 #include "utils/elog.h"
 
-#define DEBUG_PRINT(...)                \
-  do                                    \
-  {                                     \
-    printf("[PG_DIFFIX] " __VA_ARGS__); \
-    puts("");                           \
-  } while (0)
 #define DEBUG_LOG(...) ereport(LOG, (errmsg("[PG_DIFFIX] " __VA_ARGS__)))
 #define DEBUG_DUMP_NODE(label, node) ereport(LOG, (errmsg("[PG_DIFFIX] %s %s", label, nodeToString(node))))
 
 #else
 
-#define DEBUG_PRINT(...)
 #define DEBUG_LOG(...)
 #define DEBUG_DUMP_NODE(label, node)
 

--- a/src/pg_diffix.c
+++ b/src/pg_diffix.c
@@ -25,7 +25,7 @@ void _PG_init(void)
   load_diffix_config();
   config_string = config_to_string(&Config);
 
-  DEBUG_PRINT("Config %s", config_string);
+  DEBUG_LOG("Config %s", config_string);
   pfree(config_string);
 
   /*
@@ -179,7 +179,7 @@ void _PG_init(void)
 
 void _PG_fini(void)
 {
-  DEBUG_PRINT("Deactivating Diffix extension...");
+  DEBUG_LOG("Deactivating Diffix extension...");
 
   free_diffix_config();
   free_oid_cache();


### PR DESCRIPTION
Removes useless logs which we don't need right now. Merges some statements together to reduce noise.
Removes `printf` version because I thought it would have less noise, but the output gets corrupted with concurrent writes.