### PR TITLE
Allow declaring variables anywhere.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ TESTS        = $(wildcard test/sql/*.sql)
 REGRESS      = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --inputdir=test
 
-PG_CFLAGS = -std=c17
+PG_CFLAGS = -std=c17 -Wno-declaration-after-statement
 
 PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)


### PR DESCRIPTION
I think it is a good habit to declare variables on first usage. This makes it less likely that we read uninitialized memory.