### PR TITLE
Revert compatibility pg12 check

### DIFF
--- a/pg_diffix/hooks.h
+++ b/pg_diffix/hooks.h
@@ -21,9 +21,7 @@ extern void pg_diffix_post_parse_analyze(ParseState *pstate, Query *query);
 
 extern PlannedStmt *pg_diffix_planner(
     Query *parse,
-#if PG_VERSION_NUM >= PG_VERSION_13
     const char *query_string,
-#endif
     int cursorOptions,
     ParamListInfo boundParams);
 

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -61,20 +61,16 @@ void pg_diffix_post_parse_analyze(ParseState *pstate, Query *query)
 
 PlannedStmt *pg_diffix_planner(
     Query *parse,
-#if PG_VERSION_NUM >= PG_VERSION_13
     const char *query_string,
-#endif
     int cursorOptions,
     ParamListInfo boundParams)
 {
-  planner_hook_type planner = prev_planner_hook ? prev_planner_hook : standard_planner;
-
   PlannedStmt *plan;
-#if PG_VERSION_NUM >= PG_VERSION_13
-  plan = planner(parse, query_string, cursorOptions, boundParams);
-#else
-  plan = planner(parse, cursorOptions, boundParams);
-#endif
+
+  if (prev_planner_hook)
+    plan = prev_planner_hook(parse, query_string, cursorOptions, boundParams);
+  else
+    plan = standard_planner(parse, query_string, cursorOptions, boundParams);
 
   return plan;
 }


### PR DESCRIPTION
Turns out it takes a lot more to get this working on version 12. Hash functions header is missing, list functions are missing, and possibly other stuff... I'll host at 13 for now.