### PR TITLE
Properly release read lock in create_sensitive_relation

### DIFF
--- a/src/query/context.c
+++ b/src/query/context.c
@@ -37,15 +37,15 @@ static SensitiveRelation *create_sensitive_relation(Oid rel_oid, Oid namespace_o
     }
   }
 
-  table_close(rel, NoLock);
+  table_close(rel, AccessShareLock);
 
   return sensitive_rel;
 }
 
-/* Returns a list (of DiffixRelation) of all relations in the query. */
+/* Returns a list of `SensitiveRelation`s in the query range. */
 static List *gather_sensitive_relations(Query *query)
 {
-  List *result = NIL; /* List with resulting DiffixRelation */
+  List *result = NIL;
 
   ListCell *lc;
   foreach (lc, query->rtable)


### PR DESCRIPTION
I think this was a bug because it's acquiring a read lock (`AccessShareLock`) but not releasing it when closing the relation.

Relevant comment https://github.com/postgres/postgres/blob/ca3b37487be333a1d241dab1bbdd17a211a88f43/src/backend/access/common/relation.c#L196-L206