### PR TITLE
Hide noise seed from regular users.

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -94,7 +94,7 @@ void config_init(void)
       &g_config.noise_seed,                       /* valueAddr */
       "diffix",                                   /* bootValue */
       PGC_SUSET,                                  /* context */
-      0,                                          /* flags */
+      GUC_SUPERUSER_ONLY,                         /* flags */
       NULL,                                       /* check_hook */
       NULL,                                       /* assign_hook */
       NULL);                                      /* show_hook */


### PR DESCRIPTION
The noise seed should be a secret value.

At some point, we also need to force the admin to set the value manually in the config, instead of possibly relying on the default value we provide.