### PR TITLE
Support property based testing 

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ the configuration file; can't be read by regular users.
 `pg_diffix.minimum_allowed_aid_values` - The minimum number of distinct AID values that can be in a reported bucket.
 Default value is 2.
 
+`pg_diffix.lcf_range` - (**NOTE** temporarily introduced, until low count filtering is updated) The range of the noisy low count filtering threshold.
+Default value is 2.
+
 #### Aggregation settings
 
 `pg_diffix.outlier_count_min` - Default value is 1.

--- a/pg_diffix/config.h
+++ b/pg_diffix/config.h
@@ -16,6 +16,7 @@ typedef struct DiffixConfig
   double noise_cutoff;
 
   int minimum_allowed_aid_values;
+  int lcf_range;
 
   int outlier_count_min;
   int outlier_count_max;
@@ -23,8 +24,6 @@ typedef struct DiffixConfig
   int top_count_min;
   int top_count_max;
 } DiffixConfig;
-
-static const int LCF_RANGE = 2;
 
 /*
  * Global instance of root configuration.

--- a/src/aggregation/count_distinct.c
+++ b/src/aggregation/count_distinct.c
@@ -101,7 +101,7 @@ get_distinct_tracker_entry(DistinctTracker_hash *tracker, Datum value, int aids_
 
 static List *add_aidv_to_set(List *aidv, aid_t aid)
 {
-  int max_size = g_config.minimum_allowed_aid_values + LCF_RANGE + 1;
+  int max_size = g_config.minimum_allowed_aid_values + g_config.lcf_range + 1;
   if (list_length(aidv) == max_size) // set is full, value is not low-count
     return aidv;
   return list_append_unique_ptr(aidv, (void *)aid);
@@ -205,7 +205,7 @@ static bool aid_set_is_high_count(const List *aidvs)
 {
   if (list_length(aidvs) < g_config.minimum_allowed_aid_values)
     return false; /* Less AID values than minimum threshold, value is low-count. */
-  int max_size = g_config.minimum_allowed_aid_values + LCF_RANGE + 1;
+  int max_size = g_config.minimum_allowed_aid_values + g_config.lcf_range + 1;
   if (list_length(aidvs) == max_size)
     return true; /* More AID values than maximum threshold, value is high-count. */
   uint64 seed = seed_from_aidv(aidvs);

--- a/src/aggregation/random.c
+++ b/src/aggregation/random.c
@@ -60,9 +60,9 @@ double generate_noise(uint64 *seed, double sigma)
 
 int generate_lcf_threshold(uint64 *seed)
 {
-  /* Pick an integer in interval [min, min + LCF_RANGE]. */
+  /* Pick an integer in interval [min, min + lcf_range]. */
   return next_uniform_int(
       seed,
       g_config.minimum_allowed_aid_values,
-      g_config.minimum_allowed_aid_values + LCF_RANGE + 1); /* +1 because max is exclusive. */
+      g_config.minimum_allowed_aid_values + g_config.lcf_range + 1); /* +1 because max is exclusive. */
 }

--- a/src/config.c
+++ b/src/config.c
@@ -32,6 +32,7 @@ static char *config_to_string(DiffixConfig *config)
   appendStringInfo(&string, " :noise_sigma %f", config->noise_sigma);
   appendStringInfo(&string, " :noise_cutoff %f", config->noise_cutoff);
   appendStringInfo(&string, " :minimum_allowed_aid_values %i", config->minimum_allowed_aid_values);
+  appendStringInfo(&string, " :lcf_range %i", config->lcf_range);
   appendStringInfo(&string, " :outlier_count_min %i", config->outlier_count_min);
   appendStringInfo(&string, " :outlier_count_max %i", config->outlier_count_max);
   appendStringInfo(&string, " :top_count_min %i", config->top_count_min);
@@ -139,6 +140,20 @@ void config_init(void)
       &g_config.minimum_allowed_aid_values,                                          /* valueAddr */
       2,                                                                             /* bootValue */
       2,                                                                             /* minValue */
+      MAX_NUMERIC_CONFIG,                                                            /* maxValue */
+      PGC_SUSET,                                                                     /* context */
+      0,                                                                             /* flags */
+      NULL,                                                                          /* check_hook */
+      NULL,                                                                          /* assign_hook */
+      NULL);                                                                         /* show_hook */
+
+  DefineCustomIntVariable(
+      "pg_diffix.lcf_range",                                                         /* name */
+      "The range of the noisy low count filtering threshold.",                       /* short_desc */
+      NULL,                                                                          /* long_desc */
+      &g_config.lcf_range,                                                           /* valueAddr */
+      2,                                                                             /* bootValue */
+      0,                                                                             /* minValue */
       MAX_NUMERIC_CONFIG,                                                            /* maxValue */
       PGC_SUSET,                                                                     /* context */
       0,                                                                             /* flags */


### PR DESCRIPTION
This PR conflates two changes:
1/ ~introduce the infrastructure (Docker image) used to run property based testing using `reference`~ EDIT: moved to `prop-tests` repo
2/ until we bring up `pg_diffix`'s LCF up to speed with `reference` #134, we need to parametrize the `LCF_RANGE` in order to be able to set it to 0 from property tests (i.e. make suppression fully noise-less)