### PR TITLE
Check for 64-bit target during compilation.

### DIFF
--- a/src/pg_diffix.c
+++ b/src/pg_diffix.c
@@ -7,6 +7,11 @@
 #include "pg_diffix/utils.h"
 #include "pg_diffix/query/oid_cache.h"
 
+#include <limits.h>
+#if __WORDSIZE != 64
+#error "This module requires a 64-bit target architecture!"
+#endif
+
 PG_MODULE_MAGIC;
 
 void _PG_init(void);


### PR DESCRIPTION
We are storing 64-bit integers into pointer fields in at least one case, so assert that we target 64-bit architectures during compilation.