### PR TITLE
Fix crash when hashing integer AIDs. 

### DIFF
--- a/src/aggregation/aid.c
+++ b/src/aggregation/aid.c
@@ -7,21 +7,13 @@
 static aid_t make_int4_aid(Datum datum)
 {
   uint32 aid = DatumGetUInt32(datum);
-#ifdef DEBUG
-  return aid; /* We keep integer values untouched on DEBUG builds. */
-#else
   return hash_bytes(&aid, sizeof(aid));
-#endif
 }
 
 static aid_t make_int8_aid(Datum datum)
 {
   uint64 aid = DatumGetUInt64(datum);
-#ifdef DEBUG
-  return aid; /* We keep integer values untouched on DEBUG builds. */
-#else
   return hash_bytes(&aid, sizeof(aid));
-#endif
 }
 
 static aid_t make_text_aid(Datum datum)

--- a/test/expected/tests.out
+++ b/test/expected/tests.out
@@ -43,31 +43,31 @@ SELECT diffix.access_level();
 SELECT COUNT(*) FROM test_customers;
  count 
 -------
-    14
+    15
 (1 row)
 
 SELECT COUNT(*) FROM test_purchases;
  count 
 -------
-    34
+    40
 (1 row)
 
 SELECT COUNT(city), COUNT(DISTINCT city) FROM test_customers;
  count | count 
 -------+-------
-    13 |     2
+    14 |     2
 (1 row)
 
 SELECT COUNT(DISTINCT cid) FROM test_purchases;
  count 
 -------
-    13
+    15
 (1 row)
 
 SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
   city  | count 
 --------+-------
- Rome   |     6
+ Rome   |     8
  Berlin |     8
 (2 rows)
 
@@ -93,7 +93,7 @@ SELECT COUNT(*), COUNT(DISTINCT id), COUNT(DISTINCT cid) FROM test_customers
   INNER JOIN test_purchases tp ON id = cid;
  count | count | count 
 -------+-------+-------
-    34 |    13 |    13
+    40 |    15 |    15
 (1 row)
 
 SELECT COUNT(c.city), COUNT(p.name) FROM test_customers c
@@ -101,20 +101,20 @@ SELECT COUNT(c.city), COUNT(p.name) FROM test_customers c
   LEFT JOIN test_products p ON pid = p.id;
  count | count 
 -------+-------
-    33 |    29
+    39 |    34
 (1 row)
 
 SELECT city, COUNT(price) FROM test_customers, test_products GROUP BY 1;
   city  | count 
 --------+-------
- Rome   |    26
+ Rome   |    31
  Berlin |    30
 (2 rows)
 
 SELECT city, COUNT(price) FROM test_products, test_customers GROUP BY 1;
   city  | count 
 --------+-------
- Rome   |    26
+ Rome   |    31
  Berlin |    30
 (2 rows)
 
@@ -130,6 +130,8 @@ SELECT city FROM test_customers;
  Rome
  Rome
  Rome
+ Rome
+ Rome
  Berlin
  Berlin
  Berlin
@@ -138,7 +140,7 @@ SELECT city FROM test_customers;
  Berlin
  Berlin
  Berlin
-(14 rows)
+(16 rows)
 
 SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
   city  
@@ -159,7 +161,7 @@ SELECT COUNT(*) FROM test_customers WHERE city = 'London';
 SELECT COUNT(*), COUNT(x.city), COUNT(DISTINCT x.id) FROM test_customers x;
  count | count | count 
 -------+-------+-------
-    14 |    13 |    14
+    15 |    14 |    15
 (1 row)
 
 SELECT COUNT(*), COUNT(x.city), COUNT(DISTINCT x.id)
@@ -168,7 +170,7 @@ FROM (
 ) x;
  count | count | count 
 -------+-------+-------
-    14 |    13 |    14
+    15 |    14 |    15
 (1 row)
 
 SELECT COUNT(*), COUNT(x.city), COUNT(DISTINCT x.user_id)
@@ -178,7 +180,7 @@ FROM (
 ) x;
  count | count | count 
 -------+-------+-------
-    14 |    13 |    14
+    15 |    14 |    15
 (1 row)
 
 SELECT x.user_city, COUNT(*), COUNT(DISTINCT x.id), COUNT(DISTINCT x.cid)
@@ -190,14 +192,14 @@ FROM (
 GROUP BY 1;
   user_city   | count | count | count 
 --------------+-------+-------+-------
- City: Berlin |    18 |     6 |     6
- City: Rome   |    12 |     6 |     6
+ City: Berlin |    16 |     6 |     6
+ City: Rome   |    16 |     8 |     8
 (2 rows)
 
 SELECT COUNT(DISTINCT x.modified_id) FROM ( SELECT id + 1 AS modified_id FROM test_customers ) x;
  count 
 -------
-    14
+    15
 (1 row)
 
 ----------------------------------------------------------------


### PR DESCRIPTION
This bug was hidden by the conditional inclusion of hashing only in production builds.
Keeping integer AIDs raw in debug builds hasn't proven very useful until now, so it is dropped.