### PR TITLE
Fix empty AttrNumber list formatter

### DIFF
--- a/pg_node_formatter/index.js
+++ b/pg_node_formatter/index.js
@@ -61,7 +61,12 @@ function visitNode(tokens, state) {
     }
 
     state.writeNew(token.value + ' ')
-    visitValue(tokens, state)
+    const nextToken = tokens.peek()
+    // An AttrNumber array may have no tokens.
+    if (nextToken.type !== 'key' && nextToken.type !== 'nodeEnd') {
+      visitValue(tokens, state)
+    }
+
     props++
     token = tokens.next()
   }


### PR DESCRIPTION
Forgot this branch a while ago. I use this formatter to pretty-print query nodes from clipboard contents. Postgres supports such a function but I find the result quite ugly. Maybe drop this code altogether?