### PR TITLE
Discover more info through common.h

### DIFF
--- a/pg_diffix/aggregation/common.h
+++ b/pg_diffix/aggregation/common.h
@@ -120,6 +120,10 @@ struct AnonAggState
   MemoryContext memory_context;  /* Where this state lives. */
 };
 
+/*
+ * Finds aggregator spec for given OID.
+ * Returns NULL if the given OID is not an anonymizing aggregator.
+ */
 extern const AnonAggFuncs *find_agg_funcs(Oid oid);
 
 #endif /* PG_DIFFIX_COMMON_H */

--- a/src/aggregation/common.c
+++ b/src/aggregation/common.c
@@ -46,7 +46,6 @@ const AnonAggFuncs *find_agg_funcs(Oid oid)
   else if (oid == g_oid_cache.lcf)
     return &g_lcf_funcs;
 
-  FAILWITH("Unsupported anonymizing aggregator (OID %u)", oid);
   return NULL;
 }
 
@@ -64,6 +63,9 @@ static AnonAggState *get_agg_state(PG_FUNCTION_ARGS)
 
   Aggref *aggref = AggGetAggref(fcinfo);
   const AnonAggFuncs *agg_funcs = find_agg_funcs(aggref->aggfnoid);
+
+  if (unlikely(agg_funcs == NULL))
+    FAILWITH("Unsupported anonymizing aggregator (OID %u)", aggref->aggfnoid);
 
   AnonAggState *state = agg_funcs->create_state(bucket_context, fcinfo);
   Assert(state->agg_funcs == agg_funcs);


### PR DESCRIPTION
Turns out we need to use the Agg OID when declaring finalized aggregates, otherwise we'd have to pass a lot of context around.