### PR TITLE
Block anonymizing queries with subqueries/WHERE/JOIN

### DIFF
--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -15,6 +15,7 @@
     FAILWITH("Feature '%s' is not currently supported.", (feature));
 
 static void verify_query(Query *query);
+static void verify_where(Query *query);
 static void verify_rtable(Query *query);
 static void verify_aggregators(Query *query);
 static void verify_bucket_functions(Query *query);
@@ -41,9 +42,15 @@ static void verify_query(Query *query)
   NOT_SUPPORTED(query->distinctClause, "DISTINCT");
   NOT_SUPPORTED(query->setOperations, "UNION/INTERSECT");
 
+  verify_where(query);
   verify_aggregators(query);
   verify_bucket_functions(query);
   verify_rtable(query);
+}
+
+static void verify_where(Query *query)
+{
+  NOT_SUPPORTED(query->jointree->quals, "WHERE clauses in anonymizing queries");
 }
 
 static void verify_rtable(Query *query)

--- a/test/expected/tests.out
+++ b/test/expected/tests.out
@@ -21,6 +21,9 @@ INSERT INTO test_patients VALUES
   (5, 'John', 'Berlin'), (6, 'Bob', 'Berlin'), (7, 'Alice', 'Rome'), (8, 'Dan', 'Rome'), (9, 'Anna', 'Rome'),
   (10, 'Mike', 'London'), (11, 'Mike', 'London'), (12, 'Mike', 'London'), (13, 'Mike', 'London');
 CREATE TABLE empty_test_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT);
+-- Pre-filtered table to maintain LCF tests which relied on WHERE clause.
+CREATE TABLE london_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT);
+INSERT INTO london_customers (SELECT * FROM test_customers WHERE city = 'London');
 -- Config tables.
 SECURITY LABEL FOR pg_diffix ON TABLE test_customers IS 'sensitive';
 SECURITY LABEL FOR pg_diffix ON COLUMN test_customers.id IS 'aid';
@@ -31,6 +34,8 @@ SECURITY LABEL FOR pg_diffix ON COLUMN test_patients.id IS 'aid';
 SECURITY LABEL FOR pg_diffix ON COLUMN test_patients.name IS 'aid';
 SECURITY LABEL FOR pg_diffix ON TABLE empty_test_customers IS 'sensitive';
 SECURITY LABEL FOR pg_diffix ON COLUMN empty_test_customers.id IS 'aid';
+SECURITY LABEL FOR pg_diffix ON TABLE london_customers IS 'sensitive';
+SECURITY LABEL FOR pg_diffix ON COLUMN london_customers.id IS 'aid';
 ----------------------------------------------------------------
 -- Utilities
 ----------------------------------------------------------------
@@ -123,7 +128,7 @@ SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
  Berlin
 (1 row)
 
-SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM test_customers WHERE city = 'London';
+SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;
  count | count | count 
 -------+-------+-------
      0 |     0 |     0
@@ -301,3 +306,6 @@ SELECT city, COUNT(price) FROM test_products, test_customers GROUP BY 1;
 ERROR:  [PG_DIFFIX] Feature 'JOINs in anonymizing queries' is not currently supported.
 SELECT city, COUNT(price) FROM test_products CROSS JOIN test_customers GROUP BY 1;
 ERROR:  [PG_DIFFIX] Feature 'JOINs in anonymizing queries' is not currently supported.
+-- Get rejected because of WHERE
+SELECT COUNT(*) FROM test_customers WHERE city = 'London';
+ERROR:  [PG_DIFFIX] Feature 'WHERE clauses in anonymizing queries' is not currently supported.

--- a/test/sql/tests.sql
+++ b/test/sql/tests.sql
@@ -28,6 +28,10 @@ INSERT INTO test_patients VALUES
 
 CREATE TABLE empty_test_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT);
 
+-- Pre-filtered table to maintain LCF tests which relied on WHERE clause.
+CREATE TABLE london_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT);
+INSERT INTO london_customers (SELECT * FROM test_customers WHERE city = 'London');
+
 -- Config tables.
 SECURITY LABEL FOR pg_diffix ON TABLE test_customers IS 'sensitive';
 SECURITY LABEL FOR pg_diffix ON COLUMN test_customers.id IS 'aid';
@@ -38,6 +42,8 @@ SECURITY LABEL FOR pg_diffix ON COLUMN test_patients.id IS 'aid';
 SECURITY LABEL FOR pg_diffix ON COLUMN test_patients.name IS 'aid';
 SECURITY LABEL FOR pg_diffix ON TABLE empty_test_customers IS 'sensitive';
 SECURITY LABEL FOR pg_diffix ON COLUMN empty_test_customers.id IS 'aid';
+SECURITY LABEL FOR pg_diffix ON TABLE london_customers IS 'sensitive';
+SECURITY LABEL FOR pg_diffix ON COLUMN london_customers.id IS 'aid';
 
 ----------------------------------------------------------------
 -- Utilities
@@ -76,7 +82,7 @@ SELECT city FROM test_customers;
 
 SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
 
-SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM test_customers WHERE city = 'London';
+SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;
 
 ----------------------------------------------------------------
 -- Empty tables
@@ -190,3 +196,6 @@ SELECT city, COUNT(price) FROM test_customers, test_products GROUP BY 1;
 SELECT city, COUNT(price) FROM test_products, test_customers GROUP BY 1;
 
 SELECT city, COUNT(price) FROM test_products CROSS JOIN test_customers GROUP BY 1;
+
+-- Get rejected because of WHERE
+SELECT COUNT(*) FROM test_customers WHERE city = 'London';


### PR DESCRIPTION
Closes #155. Sibling of https://github.com/diffix/reference/pull/325. Should conform to the outcome of https://github.com/diffix/internal-strategy/discussions/95

An additional change here is that I've blocked anonymizing `ORDER BY` and `FILTER WHERE` for aggregates. I _think_ this is everything we should block in terms of aggregates, but I might have missed something, please double check.

Blocking `ORDER BY` might be seen as overzealous, as I don't think this could ever interfere, but let's block until we need support for it. Just in case anything funny can be done by meddling with it - like unstabilizing the SQL noise or the COUNT DISTINCT semantics or anything else.