### PR TITLE
`pfree` the result of `get_rel_name`

### DIFF
--- a/src/query/anonymization.c
+++ b/src/query/anonymization.c
@@ -461,7 +461,10 @@ static bool collect_seed_material(Node *node, CollectMaterialContext *context)
     char *relation_name = get_rel_name(rte->relid);
     /* TODO: Remove this check once anonymization over non-ordinary relations is rejected. */
     if (relation_name)
+    {
       append_seed_material(context->material, relation_name, ',');
+      pfree(relation_name);
+    }
 
     char *attribute_name = get_rte_attribute_name(rte, var_expr->varattno);
     append_seed_material(context->material, attribute_name, '.');


### PR DESCRIPTION
A little thing I noticed. I for a moment thought it's not absolutely required to `pfree` every `palloced` piece of memory very strictly, because It get's freed together with the memory context. But then I looked and noticed we do `pfree` on a similar occasion (on `get_func_name(func_expr->funcid)` just above), so here it is. LMK if this makes sense