### PR TITLE
Add clone function to agg spec

### DIFF
--- a/pg_diffix/aggregation/common.h
+++ b/pg_diffix/aggregation/common.h
@@ -9,7 +9,7 @@
  *
  * The `create_state` function must:
  *   - Switch to the provided memory context to ensure adequate lifetime of the state.
- *   - Return a derived struct with its first member of type AnonAggState (not pointer!) and populate it.
+ *   - Return a derived struct with its first member of type AnonAggState (not pointer!).
  *   - Inspect PG_FUNCTION_ARGS for type info but not values, since it may also be called during finalfunc.
  *     Argument at index 0 should be ignored because it is managed by the wrapper function.
  *   - Initialize aggregator data such as hash tables (in the provided memory context).
@@ -35,6 +35,11 @@
  *
  * Both states are known to live in the same memory context. Temporary data should be allocated
  * in the current memory context (not state's).
+ *
+ * The `clone` function must create a deep copy of given state in the same memory context.
+ * Cloning should be equivalent to merging current state to a blank state:
+ *
+ *     clone(current) == merge(new(), current)
  *
  * Memory contexts:
  *
@@ -144,6 +149,9 @@ struct AnonAggFuncs
 
   /* Merge source aggregation state to destination state. */
   void (*merge)(AnonAggState *dst_state, const AnonAggState *src_state);
+
+  /* Create a deep copy of given aggregation state. */
+  void (*clone)(AnonAggState *state);
 
   /*
    * Returns a string representation of the aggregator state.

--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -368,6 +368,7 @@ const AnonAggFuncs g_count_value_funcs = {
     count_value_transition,
     count_finalize,
     count_merge,
+    NULL /* TODO */,
     count_explain,
 };
 
@@ -408,6 +409,7 @@ const AnonAggFuncs g_count_star_funcs = {
     count_star_transition,
     count_finalize,
     count_merge,
+    NULL /* TODO */,
     count_explain,
 };
 

--- a/src/aggregation/low_count.c
+++ b/src/aggregation/low_count.c
@@ -164,6 +164,7 @@ const AnonAggFuncs g_low_count_funcs = {
     agg_transition,
     agg_finalize,
     agg_merge,
+    NULL /* TODO */,
     agg_explain,
 };
 


### PR DESCRIPTION
We have 3 options for creating the star bucket states:

1. `initial_state = clone(first low count bucket)`
2. `initial_state = create_from_template(first low count bucket)` and then `merge(initial_state, first low count bucket)`
3. Remove `PG_FUNCTION_ARGS` from functions and use a standardized argument descriptor `initial_state = create_state(args_desc)`.
 
Note that we have no access to `PG_FUNCTION_ARGS` when making the star bucket, thus we either need to get the type info from an existing state (options 1 or 2), or store args metadata (option 3)

Thoughts?