### PR TITLE
Rename the confusing function to verify_bin_size

### DIFF
--- a/pg_diffix/query/allowed_functions.h
+++ b/pg_diffix/query/allowed_functions.h
@@ -12,9 +12,9 @@ extern bool is_allowed_function(Oid funcoid);
 extern bool is_allowed_cast(Oid funcoid);
 
 /*
- * Returns whether the OID points to a UDF being a rounding function, e.g. `ceil_by(x, 2.0)`.
+ * Returns whether the OID points to a UDF being a implicit_range function, e.g. `ceil_by(x, 2.0)`.
  */
-extern bool is_rounding_udf(Oid funcoid);
+extern bool is_implicit_range_udf(Oid funcoid);
 
 /*
  * Returns whether the OID points to a built-in substring function.
@@ -22,8 +22,8 @@ extern bool is_rounding_udf(Oid funcoid);
 extern bool is_substring_builtin(Oid funcoid);
 
 /*
- * Returns whether the OID points to a built-in rounding function, e.g. `ceil(x)`.
+ * Returns whether the OID points to a built-in implicit_range function, e.g. `ceil(x)`.
  */
-extern bool is_rounding_builtin(Oid funcoid);
+extern bool is_implicit_range_builtin(Oid funcoid);
 
 #endif /* PG_DIFFIX_ALLOWED_FUNCTIONS_H */

--- a/src/query/allowed_functions.c
+++ b/src/query/allowed_functions.c
@@ -31,7 +31,7 @@ static const char *const g_substring_builtins[] = {
     /**/
 };
 
-static const char *const g_rounding_builtins[] = {
+static const char *const g_implicit_range_builtins[] = {
     "dround", "numeric_round", "dceil", "numeric_ceil", "dfloor", "numeric_floor",
     /**/
 };
@@ -41,7 +41,7 @@ static const char *const g_rounding_builtins[] = {
 static const Oid g_allowed_builtins_extra[] = {F_NUMERIC_ROUND_INT};
 
 /* Pointers to OID cache which is populated at runtime. */
-static const Oid *const g_rounding_udfs[] = {
+static const Oid *const g_implicit_range_udfs[] = {
     &g_oid_cache.round_by_nn,
     &g_oid_cache.round_by_dd,
     &g_oid_cache.ceil_by_nn,
@@ -83,11 +83,11 @@ bool is_allowed_cast(Oid funcoid)
   return is_funcname_member_of(funcoid, g_allowed_casts, ARRAY_LENGTH(g_allowed_casts));
 }
 
-bool is_rounding_udf(Oid funcoid)
+bool is_implicit_range_udf(Oid funcoid)
 {
-  for (int i = 0; i < ARRAY_LENGTH(g_rounding_udfs); i++)
+  for (int i = 0; i < ARRAY_LENGTH(g_implicit_range_udfs); i++)
   {
-    if (*g_rounding_udfs[i] == funcoid)
+    if (*g_implicit_range_udfs[i] == funcoid)
       return true;
   }
   return false;
@@ -95,7 +95,7 @@ bool is_rounding_udf(Oid funcoid)
 
 bool is_allowed_function(Oid funcoid)
 {
-  if (is_rounding_udf(funcoid))
+  if (is_implicit_range_udf(funcoid))
     return true;
 
   if (is_funcname_member_of(funcoid, g_allowed_builtins, ARRAY_LENGTH(g_allowed_builtins)))
@@ -116,7 +116,7 @@ bool is_substring_builtin(Oid funcoid)
   return is_funcname_member_of(funcoid, g_substring_builtins, ARRAY_LENGTH(g_substring_builtins));
 }
 
-bool is_rounding_builtin(Oid funcoid)
+bool is_implicit_range_builtin(Oid funcoid)
 {
-  return is_funcname_member_of(funcoid, g_rounding_builtins, ARRAY_LENGTH(g_rounding_builtins));
+  return is_funcname_member_of(funcoid, g_implicit_range_builtins, ARRAY_LENGTH(g_implicit_range_builtins));
 }

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -234,9 +234,9 @@ static void verify_generalization(Node *node)
 
     if (is_substring_builtin(func_expr->funcid))
       verify_substring(func_expr);
-    else if (is_rounding_udf(func_expr->funcid))
+    else if (is_implicit_range_udf(func_expr->funcid))
       verify_bin_size((Node *)list_nth(func_expr->args, 1));
-    else if (is_rounding_builtin(func_expr->funcid))
+    else if (is_implicit_range_builtin(func_expr->funcid))
       ;
     else
       FAILWITH_LOCATION(func_expr->location, "Generalization used in the query is not allowed in untrusted access level.");


### PR DESCRIPTION
This is just a rename of the function which had a controversial name. `bin_size` is in line with the term we use in `desktop`. I wasn't sold on `implicit_range` but `binning` is named in `desktop` as a synonym of `generalization`, and `generalization` is a general term encompassing `substring`. So I went with `implicit_range`