### PR TITLE
Use internal as base type of AnonAggState

### DIFF
--- a/pg_diffix--0.0.1.sql
+++ b/pg_diffix--0.0.1.sql
@@ -71,7 +71,7 @@ LANGUAGE C STRICT STABLE;
 CREATE TYPE AnonAggState (
   INPUT = diffix.anon_agg_state_input,
   OUTPUT = diffix.anon_agg_state_output,
-  LIKE = int8
+  LIKE = internal
 );
 
 CREATE FUNCTION diffix.anon_agg_state_transfn(AnonAggState, variadic aids "any")

--- a/src/aggregation/common.c
+++ b/src/aggregation/common.c
@@ -6,9 +6,9 @@
 #include "pg_diffix/oid_cache.h"
 #include "pg_diffix/utils.h"
 
-/* See AggState definition in SQL. */
-#define PG_GET_AGG_STATE(index) ((AnonAggState *)PG_GETARG_INT64(index))
-#define PG_RETURN_AGG_STATE(state) PG_RETURN_INT64(state)
+/* See AnonAggState definition in SQL. */
+#define PG_GET_AGG_STATE(index) ((AnonAggState *)PG_GETARG_POINTER(index))
+#define PG_RETURN_AGG_STATE(state) PG_RETURN_POINTER(state)
 
 /* Memory context of currently executing BucketScan node (if any). */
 extern MemoryContext g_current_bucket_context;


### PR DESCRIPTION
Didn't know it was possible. It's cleaner this way because the underlying type always matches pointer.