### PR TITLE
Convert count_distinct to new interface - without merge, without full explain

### DIFF
--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -435,7 +435,9 @@ static AnonAggState *count_get_state(PG_FUNCTION_ARGS, int aids_offset)
   if (AggCheckCallContext(fcinfo, &memory_context) != AGG_CONTEXT_AGGREGATE)
     FAILWITH("Aggregate called in non-aggregate context");
 
-  return count_create_state(memory_context, get_args_desc(fcinfo), aids_offset);
+  AnonAggState *state = count_create_state(memory_context, get_args_desc(fcinfo), aids_offset);
+  state->memory_context = memory_context;
+  return state;
 }
 
 PG_FUNCTION_INFO_V1(anon_count_value_transfn);


### PR DESCRIPTION
Related to #182 , but still misses two points as in title.

I needed to do one modification which also touched `count.c` I'm unsure of - this regards the way `memory_context` is stored in `AnonAggState`, when creating it through "legacy" UDFs (where `get_agg_state` isn't called). I took some code out of `get_agg_state` and called it from the "legacy" UDFs. If I don't do that, then in my `transition` function, `base_state->memory_context` is nil, and I don't have a context to switch to to perform allocations.

Let me know if this is good.

Merging and explain - these two I'll work on in subsequent PRs.