### PR TITLE
Validate count arguments

### DIFF
--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -178,7 +178,9 @@ static bool verify_aggregator(Node *node, void *context)
     Aggref *aggref = (Aggref *)node;
     Oid aggoid = aggref->aggfnoid;
 
-    if (aggoid != g_oid_cache.count_star && aggoid != g_oid_cache.count_value)
+    if (aggoid != g_oid_cache.count_star &&
+        aggoid != g_oid_cache.count_value &&
+        aggoid != g_oid_cache.is_suppress_bin)
       FAILWITH_LOCATION(aggref->location, "Unsupported aggregate in query.");
 
     if (aggoid == g_oid_cache.count_value)

--- a/test/expected/validation_trusted.out
+++ b/test/expected/validation_trusted.out
@@ -90,6 +90,12 @@ SELECT 2 * length(city) FROM empty_test_customers GROUP BY city;
 ----------
 (0 rows)
 
+-- Allow diffix.is_suppress_bin in non-direct access level
+SELECT city, count(*), diffix.is_suppress_bin(*) from empty_test_customers GROUP BY 1;
+ city | count | is_suppress_bin 
+------+-------+-----------------
+(0 rows)
+
 ----------------------------------------------------------------
 -- Unsupported queries
 ----------------------------------------------------------------

--- a/test/sql/validation_trusted.sql
+++ b/test/sql/validation_trusted.sql
@@ -60,6 +60,9 @@ GROUP BY 1, 2, 3;
 -- Allow all functions post-anonymization
 SELECT 2 * length(city) FROM empty_test_customers GROUP BY city;
 
+-- Allow diffix.is_suppress_bin in non-direct access level
+SELECT city, count(*), diffix.is_suppress_bin(*) from empty_test_customers GROUP BY 1;
+
 ----------------------------------------------------------------
 -- Unsupported queries
 ----------------------------------------------------------------


### PR DESCRIPTION
This is a follow up to one of the earlier PRs related to #234.

It turned out we're not verifying the aggregate arguments, like we do in `reference`, so here it.

The big diff is because portions of `validation.c` needed to be moved upwards. The part that is actually new is the `if (aggoid == g_oid_cache.count_value)`
