### PR TITLE
Add a test case for the min_count behavior with count distinct

### DIFF
--- a/test/expected/_setup.out
+++ b/test/expected/_setup.out
@@ -1,11 +1,12 @@
 CREATE EXTENSION IF NOT EXISTS pg_diffix;
 LOAD 'pg_diffix';
 -- Create test data.
-CREATE TABLE test_customers (id INTEGER PRIMARY KEY, city TEXT, discount REAL);
+CREATE TABLE test_customers (id INTEGER PRIMARY KEY, city TEXT, discount REAL, planet TEXT);
 INSERT INTO test_customers VALUES
-  (0, NULL, NULL), (1, 'Berlin', 1.0), (2, 'Berlin', 1.0), (3, 'Rome', 0.5), (4, 'London', 2.0), (5, 'Berlin', 2.0),
-  (6, 'Rome', 1.0), (7, 'Rome', 0.5), (8, 'Berlin', 0.0), (9, 'Rome', 1.0), (10, 'Berlin', 2.0), (11, 'Rome', 1.5),
-  (12, 'Rome', 0.5), (13, 'Rome', 0.5), (14, 'Berlin', 1.5), (15, 'Berlin', 1.0);
+  (0, NULL, NULL, NULL), (1, 'Berlin', 1.0, 'Earth'), (2, 'Berlin', 1.0, 'Earth'), (3, 'Rome', 0.5, 'Earth'),
+  (4, 'London', 2.0, 'Earth'), (5, 'Berlin', 2.0, 'Earth'), (6, 'Rome', 1.0, 'Earth'), (7, 'Rome', 0.5, 'Earth'),
+  (8, 'Berlin', 0.0, 'Earth'), (9, 'Rome', 1.0, 'Earth'), (10, 'Berlin', 2.0, 'Earth'), (11, 'Rome', 1.5, 'Earth'),
+  (12, 'Rome', 0.5, 'Earth'), (13, 'Rome', 0.5, 'Earth'), (14, 'Berlin', 1.5, 'Earth'), (15, 'Berlin', 1.0, 'Earth');
 CREATE TABLE test_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
 INSERT INTO test_products VALUES (0, NULL, NULL), (1, 'Food', 1.5),
   (2, 'Car', 100.0), (3, 'House', 400.0), (4, 'Movie', 10.0);
@@ -21,8 +22,7 @@ INSERT INTO test_patients VALUES
   (10, 'Mike', 'London'), (11, 'Mike', 'London'), (12, 'Mike', 'London'), (13, 'Mike', 'London');
 CREATE TABLE empty_test_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT, discount REAL);
 -- Pre-filtered table to maintain LCF tests which relied on WHERE clause.
-CREATE TABLE london_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT);
-INSERT INTO london_customers (SELECT * FROM test_customers WHERE city = 'London');
+CREATE TABLE london_customers AS (SELECT * FROM test_customers WHERE city = 'London');
 CREATE TABLE empty_test_times (cid INTEGER PRIMARY key, birthday DATE, lunchtime TIME, last_seen TIMESTAMP);
 CREATE TABLE superclass (x INTEGER);
 CREATE TABLE subclass (x INTEGER, y INTEGER);

--- a/test/expected/noiseless.out
+++ b/test/expected/noiseless.out
@@ -216,3 +216,32 @@ SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM empty_test_customers;
      0 |     0 |     0
 (1 row)
 
+----------------------------------------------------------------
+-- Minimal count
+----------------------------------------------------------------
+-- Zero for global aggregation
+SELECT COUNT(DISTINCT planet) FROM test_customers;
+ count 
+-------
+     1
+(1 row)
+
+-- `low_count_min_threshold` for queries with GROUP BY
+SELECT city, COUNT(DISTINCT city) FROM test_customers GROUP BY 1;
+  city  | count 
+--------+-------
+ *      |     2
+ Rome   |     2
+ Berlin |     2
+(3 rows)
+
+SELECT discount, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
+ discount | count 
+----------+-------
+          |     2
+      1.5 |     2
+      0.5 |     4
+        1 |     5
+        2 |     2
+(5 rows)
+

--- a/test/sql/_setup.sql
+++ b/test/sql/_setup.sql
@@ -2,11 +2,12 @@ CREATE EXTENSION IF NOT EXISTS pg_diffix;
 LOAD 'pg_diffix';
 
 -- Create test data.
-CREATE TABLE test_customers (id INTEGER PRIMARY KEY, city TEXT, discount REAL);
+CREATE TABLE test_customers (id INTEGER PRIMARY KEY, city TEXT, discount REAL, planet TEXT);
 INSERT INTO test_customers VALUES
-  (0, NULL, NULL), (1, 'Berlin', 1.0), (2, 'Berlin', 1.0), (3, 'Rome', 0.5), (4, 'London', 2.0), (5, 'Berlin', 2.0),
-  (6, 'Rome', 1.0), (7, 'Rome', 0.5), (8, 'Berlin', 0.0), (9, 'Rome', 1.0), (10, 'Berlin', 2.0), (11, 'Rome', 1.5),
-  (12, 'Rome', 0.5), (13, 'Rome', 0.5), (14, 'Berlin', 1.5), (15, 'Berlin', 1.0);
+  (0, NULL, NULL, NULL), (1, 'Berlin', 1.0, 'Earth'), (2, 'Berlin', 1.0, 'Earth'), (3, 'Rome', 0.5, 'Earth'),
+  (4, 'London', 2.0, 'Earth'), (5, 'Berlin', 2.0, 'Earth'), (6, 'Rome', 1.0, 'Earth'), (7, 'Rome', 0.5, 'Earth'),
+  (8, 'Berlin', 0.0, 'Earth'), (9, 'Rome', 1.0, 'Earth'), (10, 'Berlin', 2.0, 'Earth'), (11, 'Rome', 1.5, 'Earth'),
+  (12, 'Rome', 0.5, 'Earth'), (13, 'Rome', 0.5, 'Earth'), (14, 'Berlin', 1.5, 'Earth'), (15, 'Berlin', 1.0, 'Earth');
 
 CREATE TABLE test_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
 INSERT INTO test_products VALUES (0, NULL, NULL), (1, 'Food', 1.5),
@@ -27,8 +28,7 @@ INSERT INTO test_patients VALUES
 CREATE TABLE empty_test_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT, discount REAL);
 
 -- Pre-filtered table to maintain LCF tests which relied on WHERE clause.
-CREATE TABLE london_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT);
-INSERT INTO london_customers (SELECT * FROM test_customers WHERE city = 'London');
+CREATE TABLE london_customers AS (SELECT * FROM test_customers WHERE city = 'London');
 
 CREATE TABLE empty_test_times (cid INTEGER PRIMARY key, birthday DATE, lunchtime TIME, last_seen TIMESTAMP);
 

--- a/test/sql/noiseless.sql
+++ b/test/sql/noiseless.sql
@@ -64,3 +64,14 @@ SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;
 ----------------------------------------------------------------
 
 SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM empty_test_customers;
+
+----------------------------------------------------------------
+-- Minimal count
+----------------------------------------------------------------
+
+-- Zero for global aggregation
+SELECT COUNT(DISTINCT planet) FROM test_customers;
+
+-- `low_count_min_threshold` for queries with GROUP BY
+SELECT city, COUNT(DISTINCT city) FROM test_customers GROUP BY 1;
+SELECT discount, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;


### PR DESCRIPTION
We've had a discussion on Slack about `min_count`. Since it now works the same as `reference`, here's a new `.sql` test to check this behavior.