### PR TITLE
Support rewinding bucketscan

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -72,7 +72,7 @@ static bool session_access_level_check(int *newval, void **extra, GucSource sour
   return true;
 }
 
-// `check_hook`s for intervals only issue warnings, so they only make sense in interactive mode
+/* `check_hook`s for intervals only issue warnings, so they only make sense in interactive mode. */
 static bool outlier_count_min_check_hook(int *newval, void **extra, GucSource source)
 {
   if (source >= PGC_S_INTERACTIVE && *newval > g_config.outlier_count_max)

--- a/test/expected/misc.out
+++ b/test/expected/misc.out
@@ -1,6 +1,35 @@
 LOAD 'pg_diffix';
+SET pg_diffix.low_count_min_threshold = 2;
+SET pg_diffix.low_count_layer_sd = 0;
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'publish_trusted';
+----------------------------------------------------------------
+-- Post processing anonymized results
+----------------------------------------------------------------
+SELECT * FROM
+  (SELECT count(*) AS num_purchases FROM test_purchases) x,
+  (SELECT count(*) AS num_customers FROM test_customers) y;
+ num_purchases | num_customers 
+---------------+---------------
+            34 |            16
+(1 row)
+
+SELECT
+  coalesce(patients.city, customers.city) AS city,
+  customers.count AS num_customers,
+  patients.count AS num_patients
+FROM
+  (SELECT city, count(*) FROM test_patients GROUP BY 1) patients
+FULL OUTER JOIN
+  (SELECT city, count(*) FROM test_customers GROUP BY 1) customers
+ON patients.city = customers.city;
+  city  | num_customers | num_patients 
+--------+---------------+--------------
+ Rome   |             7 |            2
+ Berlin |            10 |            2
+ *      |             2 |             
+(3 rows)
+
 ----------------------------------------------------------------
 -- Miscellaneous queries
 ----------------------------------------------------------------

--- a/test/sql/misc.sql
+++ b/test/sql/misc.sql
@@ -1,7 +1,28 @@
 LOAD 'pg_diffix';
 
+SET pg_diffix.low_count_min_threshold = 2;
+SET pg_diffix.low_count_layer_sd = 0;
+
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'publish_trusted';
+
+----------------------------------------------------------------
+-- Post processing anonymized results
+----------------------------------------------------------------
+
+SELECT * FROM
+  (SELECT count(*) AS num_purchases FROM test_purchases) x,
+  (SELECT count(*) AS num_customers FROM test_customers) y;
+
+SELECT
+  coalesce(patients.city, customers.city) AS city,
+  customers.count AS num_customers,
+  patients.count AS num_patients
+FROM
+  (SELECT city, count(*) FROM test_patients GROUP BY 1) patients
+FULL OUTER JOIN
+  (SELECT city, count(*) FROM test_customers GROUP BY 1) customers
+ON patients.city = customers.city;
 
 ----------------------------------------------------------------
 -- Miscellaneous queries


### PR DESCRIPTION
Closes #271.

I can't actually get the rescan code to run because the planner keeps shielding the repeated node with materialize.