### PR TITLE
Optimize count distinct

### DIFF
--- a/src/aggregation/count_distinct.c
+++ b/src/aggregation/count_distinct.c
@@ -255,7 +255,7 @@ typedef struct DatumSetEntry
 #define SH_KEY value
 #define SH_KEY_TYPE Datum
 #define SH_EQUAL(tb, a, b) (a == b)
-#define SH_HASH_KEY(tb, key) ((uint32)key)
+#define SH_HASH_KEY(tb, key) (uint32) hash_bytes(&key, sizeof(Datum))
 #define SH_SCOPE static inline
 #define SH_DECLARE
 #define SH_DEFINE


### PR DESCRIPTION
closes #275 

This cuts the test time down from 167s to 2s (1s with `simplehash.h`) on my machine.

This is a similar approach as `reference`. At first commit I'm stopping at using a list instead of a hash set for simplicity. The second commit takes a step further and uses `simplehash.h`, (just without any hashing, as we operate on pointers to unique values). On my end this does an additional 2x speedup on the test case.

One could probably do away with the HashSet, this is a bit overshot, but I don't want to roll anything own, WDYT?