### PR TITLE
Formatter: Enfore a strict limit on column width

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,6 @@ IndentWidth: 2
 BreakBeforeBraces: Allman
 AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: false
-ColumnLimit: 0
+ColumnLimit: 120
+AllowShortBlocksOnASingleLine: Never
+AllowShortFunctionsOnASingleLine: None

--- a/pg_diffix/aggregation/common.h
+++ b/pg_diffix/aggregation/common.h
@@ -198,8 +198,7 @@ struct AnonAggState
 /*
  * Creates an empty AnonAggState state for given AnonAggFuncs.
  */
-static inline AnonAggState *create_anon_agg_state(const AnonAggFuncs *agg_funcs,
-                                                  MemoryContext bucket_context,
+static inline AnonAggState *create_anon_agg_state(const AnonAggFuncs *agg_funcs, MemoryContext bucket_context,
                                                   ArgsDescriptor *args_desc)
 {
   AnonAggState *state = agg_funcs->create_state(bucket_context, args_desc);

--- a/pg_diffix/aggregation/contribution_tracker.h
+++ b/pg_diffix/aggregation/contribution_tracker.h
@@ -81,27 +81,19 @@ extern void contribution_tracker_update_aid(ContributionTrackerState *state, aid
 /*
  * Updates state with a contribution from an AID.
  */
-extern void contribution_tracker_update_contribution(
-    ContributionTrackerState *state,
-    aid_t aid,
-    contribution_t contribution);
+extern void contribution_tracker_update_contribution(ContributionTrackerState *state, aid_t aid,
+                                                     contribution_t contribution);
 
 /*
  * Gets or creates the multi-AID aggregation state from the function arguments.
  */
-extern List *create_contribution_trackers(
-    ArgsDescriptor *args_desc,
-    int aids_offset,
-    const ContributionDescriptor *descriptor);
+extern List *create_contribution_trackers(ArgsDescriptor *args_desc, int aids_offset,
+                                          const ContributionDescriptor *descriptor);
 
-extern void add_top_contributor(
-    const ContributionDescriptor *descriptor,
-    Contributors *top_contributors,
-    Contributor contributor);
+extern void add_top_contributor(const ContributionDescriptor *descriptor, Contributors *top_contributors,
+                                Contributor contributor);
 
-extern void update_or_add_top_contributor(
-    const ContributionDescriptor *descriptor,
-    Contributors *top_contributors,
-    Contributor contributor);
+extern void update_or_add_top_contributor(const ContributionDescriptor *descriptor, Contributors *top_contributors,
+                                          Contributor contributor);
 
 #endif /* PG_DIFFIX_CONTRIBUTION_TRACKER_H */

--- a/pg_diffix/aggregation/count.h
+++ b/pg_diffix/aggregation/count.h
@@ -22,10 +22,9 @@ typedef struct CountResult
   bool not_enough_aid_values;
 } CountResult;
 
-extern CountResult aggregate_count_contributions(
-    seed_t bucket_seed, seed_t aid_seed, const char *salt,
-    uint64 true_count, uint64 distinct_contributors, uint64 unacounted_for,
-    const Contributors *top_contributors);
+extern CountResult aggregate_count_contributions(seed_t bucket_seed, seed_t aid_seed, const char *salt,
+                                                 uint64 true_count, uint64 distinct_contributors, uint64 unacounted_for,
+                                                 const Contributors *top_contributors);
 
 /*
  * Helper data structure and functions to combine multiple count results into one value.

--- a/pg_diffix/aggregation/noise.h
+++ b/pg_diffix/aggregation/noise.h
@@ -11,8 +11,7 @@ extern int generate_uniform_noise(seed_t seed, const char *salt, const char *ste
 /*
  * Returns the combined zero-mean gaussian noise value for the given noise layers and step name.
  */
-extern double generate_layered_noise(const seed_t *seeds, int seeds_count,
-                                     const char *salt, const char *step_name,
+extern double generate_layered_noise(const seed_t *seeds, int seeds_count, const char *salt, const char *step_name,
                                      double layer_sd);
 
 /*

--- a/pg_diffix/auth.h
+++ b/pg_diffix/auth.h
@@ -9,7 +9,8 @@ typedef enum AccessLevel
 {
   ACCESS_DIRECT,           /* No protection - access to raw data. */
   ACCESS_PUBLISH_TRUSTED,  /* Publish access level, trusted analyst; protects against accidental re-identification. */
-  ACCESS_PUBLISH_UNTRUSTED /* Publish access level, untrusted analyst; protects against intentional re-identification. */
+  ACCESS_PUBLISH_UNTRUSTED /* Publish access level, untrusted analyst; protects against intentional re-identification.
+                            */
 } AccessLevel;
 
 /* Returns true if the first access level is higher privilege than the second one. */

--- a/pg_diffix/utils.h
+++ b/pg_diffix/utils.h
@@ -103,10 +103,7 @@ typedef void *(*MapTupleFunc)(HeapTuple heap_tuple, TupleDesc tuple_desc);
  */
 extern List *scan_table(Oid rel_oid, MapTupleFunc map_tuple);
 
-static inline List *scan_table_by_name(
-    const char *rel_ns_name,
-    const char *rel_name,
-    MapTupleFunc map_tuple)
+static inline List *scan_table_by_name(const char *rel_ns_name, const char *rel_name, MapTupleFunc map_tuple)
 {
   Oid rel_oid = get_rel_oid(rel_ns_name, rel_name);
   return scan_table(rel_oid, map_tuple);
@@ -121,25 +118,21 @@ static inline List *scan_table_by_name(
 
 #define FAILWITH(...) ereport(ERROR, (errmsg("[PG_DIFFIX] " __VA_ARGS__)))
 
-#define FAILWITH_LOCATION(cursorpos, ...) \
+#define FAILWITH_LOCATION(cursorpos, ...)                                                                              \
   ereport(ERROR, (errmsg("[PG_DIFFIX] " __VA_ARGS__), errposition((cursorpos) + 1)))
 
 #define FAILWITH_CODE(code, ...) ereport(ERROR, (errcode(code), errmsg("[PG_DIFFIX] " __VA_ARGS__)))
 
 #ifdef DEBUG
 
-#define DEBUG_LOG(...) ereport(LOG,                                \
-                               errmsg("[PG_DIFFIX] " __VA_ARGS__), \
-                               errhidestmt(true))
+#define DEBUG_LOG(...) ereport(LOG, errmsg("[PG_DIFFIX] " __VA_ARGS__), errhidestmt(true))
 
-#define DEBUG_DUMP_NODE(label, node)                      \
-  do                                                      \
-  {                                                       \
-    char *node_str = nodeToString(node);                  \
-    ereport(LOG,                                          \
-            errmsg("[PG_DIFFIX] %s %s", label, node_str), \
-            errhidestmt(true));                           \
-    pfree(node_str);                                      \
+#define DEBUG_DUMP_NODE(label, node)                                                                                   \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    char *node_str = nodeToString(node);                                                                               \
+    ereport(LOG, errmsg("[PG_DIFFIX] %s %s", label, node_str), errhidestmt(true));                                     \
+    pfree(node_str);                                                                                                   \
   } while (0)
 
 #else

--- a/src/aggregation/bucket_scan.c
+++ b/src/aggregation/bucket_scan.c
@@ -216,7 +216,8 @@ static void bucket_begin_scan(CustomScanState *css, EState *estate, int eflags)
   if (eflags & (EXEC_FLAG_BACKWARD | EXEC_FLAG_MARK))
     FAILWITH("Cannot BACKWARD or MARK/RESTORE a BucketScan.");
 
-  bucket_state->bucket_context = AllocSetContextCreate(estate->es_query_cxt, "BucketScan context", ALLOCSET_DEFAULT_SIZES);
+  bucket_state->bucket_context =
+      AllocSetContextCreate(estate->es_query_cxt, "BucketScan context", ALLOCSET_DEFAULT_SIZES);
   bucket_state->buckets = NIL;
   bucket_state->repeat_previous_bucket = 0;
   bucket_state->next_bucket_index = 1;
@@ -273,9 +274,8 @@ static void fill_bucket_list(BucketScanState *bucket_state)
       if (outer_slot->tts_isnull[i])
         bucket->is_null[i] = true;
       else
-        bucket->values[i] = datumCopy(outer_slot->tts_values[i],
-                                      bucket_desc->attrs[i].typ_byval,
-                                      bucket_desc->attrs[i].typ_len);
+        bucket->values[i] =
+            datumCopy(outer_slot->tts_values[i], bucket_desc->attrs[i].typ_byval, bucket_desc->attrs[i].typ_len);
     }
 
     buckets = lappend(buckets, bucket);
@@ -658,11 +658,8 @@ static List *project_agg_tlist(List *orig_agg_tlist, RewriteProjectionContext *c
   {
     TargetEntry *orig_tle = lfirst_node(TargetEntry, cell);
 
-    TargetEntry *projected_tle = makeTargetEntry(
-        (Expr *)rewrite_projection_mutator((Node *)orig_tle->expr, context),
-        orig_tle->resno,
-        orig_tle->resname,
-        orig_tle->resjunk);
+    TargetEntry *projected_tle = makeTargetEntry((Expr *)rewrite_projection_mutator((Node *)orig_tle->expr, context),
+                                                 orig_tle->resno, orig_tle->resname, orig_tle->resjunk);
 
     projected_tle->resorigtbl = orig_tle->resorigtbl;
     projected_tle->resorigcol = orig_tle->resorigcol;
@@ -775,44 +772,39 @@ Plan *make_bucket_scan(Plan *left_tree, AnonymizationContext *anon_context)
 
 /* Subset of macros from outfuncs.c & copyfuncs.c. */
 
-#define WRITE_INT_FIELD(fldname) \
-  appendStringInfo(str, " :" CppAsString(fldname) " %d", node->fldname)
+#define WRITE_INT_FIELD(fldname) appendStringInfo(str, " :" CppAsString(fldname) " %d", node->fldname)
 
-#define WRITE_NODE_FIELD(fldname)                              \
-  (appendStringInfoString(str, " :" CppAsString(fldname) " "), \
-   outNode(str, node->fldname))
+#define WRITE_NODE_FIELD(fldname)                                                                                      \
+  (appendStringInfoString(str, " :" CppAsString(fldname) " "), outNode(str, node->fldname))
 
-#define WRITE_BOOL_FIELD(fldname) \
-  appendStringInfo(str, " :" CppAsString(fldname) " %s", booltostr(node->fldname))
+#define WRITE_BOOL_FIELD(fldname) appendStringInfo(str, " :" CppAsString(fldname) " %s", booltostr(node->fldname))
 
-#define WRITE_SEED_FIELD(fldname) \
+#define WRITE_SEED_FIELD(fldname)                                                                                      \
   appendStringInfo(str, " :" CppAsString(fldname) " %" INT64_MODIFIER "x", node->fldname)
 
-#define WRITE_ATTRNUMBER_ARRAY(fldname, len)                    \
-  do                                                            \
-  {                                                             \
-    appendStringInfoString(str, " :" CppAsString(fldname) " "); \
-    for (int i = 0; i < len; i++)                               \
-      appendStringInfo(str, " %d", node->fldname[i]);           \
+#define WRITE_ATTRNUMBER_ARRAY(fldname, len)                                                                           \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    appendStringInfoString(str, " :" CppAsString(fldname) " ");                                                        \
+    for (int i = 0; i < len; i++)                                                                                      \
+      appendStringInfo(str, " %d", node->fldname[i]);                                                                  \
   } while (0)
 
 #define booltostr(x) ((x) ? "true" : "false")
 
-#define COPY_SCALAR_FIELD(fldname) \
-  (dst->fldname = src->fldname)
+#define COPY_SCALAR_FIELD(fldname) (dst->fldname = src->fldname)
 
-#define COPY_NODE_FIELD(fldname) \
-  (dst->fldname = copyObjectImpl(src->fldname))
+#define COPY_NODE_FIELD(fldname) (dst->fldname = copyObjectImpl(src->fldname))
 
-#define COPY_POINTER_FIELD(fldname, sz)          \
-  do                                             \
-  {                                              \
-    Size _size = (sz);                           \
-    if (_size > 0)                               \
-    {                                            \
-      dst->fldname = palloc(_size);              \
-      memcpy(dst->fldname, src->fldname, _size); \
-    }                                            \
+#define COPY_POINTER_FIELD(fldname, sz)                                                                                \
+  do                                                                                                                   \
+  {                                                                                                                    \
+    Size _size = (sz);                                                                                                 \
+    if (_size > 0)                                                                                                     \
+    {                                                                                                                  \
+      dst->fldname = palloc(_size);                                                                                    \
+      memcpy(dst->fldname, src->fldname, _size);                                                                       \
+    }                                                                                                                  \
   } while (0)
 
 static void bucket_scan_data_copy(ExtensibleNode *dst_node, const ExtensibleNode *src_node)

--- a/src/aggregation/contribution_tracker.c
+++ b/src/aggregation/contribution_tracker.c
@@ -20,10 +20,8 @@ static inline uint32 find_aid_index(const Contributors *top_contributors, aid_t 
   return top_contributors->length;
 }
 
-static inline uint32 find_insertion_index(
-    const ContributionDescriptor *descriptor,
-    const Contributors *top_contributors,
-    contribution_t contribution)
+static inline uint32 find_insertion_index(const ContributionDescriptor *descriptor,
+                                          const Contributors *top_contributors, contribution_t contribution)
 {
   ContributionGreaterFunc greater = descriptor->contribution_greater;
 
@@ -42,10 +40,8 @@ static inline uint32 find_insertion_index(
   return top_contributors->length;
 }
 
-void add_top_contributor(
-    const ContributionDescriptor *descriptor,
-    Contributors *top_contributors,
-    Contributor contributor)
+void add_top_contributor(const ContributionDescriptor *descriptor, Contributors *top_contributors,
+                         Contributor contributor)
 {
   uint32 length = top_contributors->length, capacity = top_contributors->capacity;
   Assert(capacity >= length);
@@ -66,18 +62,15 @@ void add_top_contributor(
 
   /* Slide items to the right before inserting new item. */
   size_t elements = (length < capacity ? length + 1 : capacity) - insertion_index - 1;
-  memmove(&top_contributors->members[insertion_index + 1],
-          &top_contributors->members[insertion_index],
+  memmove(&top_contributors->members[insertion_index + 1], &top_contributors->members[insertion_index],
           elements * sizeof(Contributor));
 
   top_contributors->members[insertion_index] = contributor;
   top_contributors->length = Min(length + 1, capacity);
 }
 
-void update_or_add_top_contributor(
-    const ContributionDescriptor *descriptor,
-    Contributors *top_contributors,
-    Contributor contributor)
+void update_or_add_top_contributor(const ContributionDescriptor *descriptor, Contributors *top_contributors,
+                                   Contributor contributor)
 {
   Assert(top_contributors->capacity >= top_contributors->length);
 
@@ -93,8 +86,7 @@ void update_or_add_top_contributor(
   Assert(insertion_index <= aid_index); /* sanity check */
 
   size_t elements = aid_index - insertion_index;
-  memmove(&top_contributors->members[insertion_index + 1],
-          &top_contributors->members[insertion_index],
+  memmove(&top_contributors->members[insertion_index + 1], &top_contributors->members[insertion_index],
           elements * sizeof(Contributor));
 
   top_contributors->members[insertion_index] = contributor;
@@ -118,9 +110,8 @@ void update_or_add_top_contributor(
 #define SH_DEFINE
 #include "lib/simplehash.h"
 
-static ContributionTrackerState *contribution_tracker_new(
-    AidDescriptor aid_descriptor,
-    const ContributionDescriptor *contribution_descriptor)
+static ContributionTrackerState *contribution_tracker_new(AidDescriptor aid_descriptor,
+                                                          const ContributionDescriptor *contribution_descriptor)
 {
   uint32 top_capacity = g_config.outlier_count_max + g_config.top_count_max;
   ContributionTrackerState *state = palloc0(sizeof(ContributionTrackerState) + top_capacity * sizeof(Contributor));
@@ -150,10 +141,7 @@ void contribution_tracker_update_aid(ContributionTrackerState *state, aid_t aid)
   }
 }
 
-void contribution_tracker_update_contribution(
-    ContributionTrackerState *state,
-    aid_t aid,
-    contribution_t contribution)
+void contribution_tracker_update_contribution(ContributionTrackerState *state, aid_t aid, contribution_t contribution)
 {
   ContributionDescriptor *descriptor = &state->contribution_descriptor;
 
@@ -169,9 +157,7 @@ void contribution_tracker_update_contribution(
     state->distinct_contributors++;
     state->aid_seed ^= aid;
 
-    add_top_contributor(&state->contribution_descriptor,
-                        &state->top_contributors,
-                        entry->contributor);
+    add_top_contributor(&state->contribution_descriptor, &state->top_contributors, entry->contributor);
     return;
   }
   else if (!entry->has_contribution)
@@ -180,10 +166,7 @@ void contribution_tracker_update_contribution(
     entry->has_contribution = true;
     entry->contributor.contribution = contribution;
 
-    add_top_contributor(
-        &state->contribution_descriptor,
-        &state->top_contributors,
-        entry->contributor);
+    add_top_contributor(&state->contribution_descriptor, &state->top_contributors, entry->contributor);
     return;
   }
 
@@ -191,16 +174,10 @@ void contribution_tracker_update_contribution(
   entry->contributor.contribution = descriptor->contribution_combine(entry->contributor.contribution, contribution);
 
   /* We have to check for existence first. If it exists we bump, otherwise we try to insert. */
-  update_or_add_top_contributor(
-      &state->contribution_descriptor,
-      &state->top_contributors,
-      entry->contributor);
+  update_or_add_top_contributor(&state->contribution_descriptor, &state->top_contributors, entry->contributor);
 }
 
-List *create_contribution_trackers(
-    ArgsDescriptor *args_desc,
-    int aids_offset,
-    const ContributionDescriptor *descriptor)
+List *create_contribution_trackers(ArgsDescriptor *args_desc, int aids_offset, const ContributionDescriptor *descriptor)
 {
   Assert(args_desc->num_args > aids_offset);
 

--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -38,11 +38,8 @@ static seed_t contributors_seed(const Contributor *contributors, int count)
   return seed;
 }
 
-static void determine_outlier_top_counts(
-    uint64 total_count,
-    const Contributors *top_contributors,
-    CountResult *result,
-    const char *salt)
+static void determine_outlier_top_counts(uint64 total_count, const Contributors *top_contributors, CountResult *result,
+                                         const char *salt)
 {
   /* Compact flattening intervals */
   int total_adjustment = g_config.outlier_count_max + g_config.top_count_max - total_count;
@@ -71,19 +68,18 @@ static void determine_outlier_top_counts(
   }
 
   /* Determine noisy outlier/top counts. */
-  seed_t flattening_seed = contributors_seed(
-      top_contributors->members, compact_outlier_count_max + compact_top_count_max);
+  seed_t flattening_seed =
+      contributors_seed(top_contributors->members, compact_outlier_count_max + compact_top_count_max);
 
-  result->noisy_outlier_count = generate_uniform_noise(
-      flattening_seed, salt, "outlier", g_config.outlier_count_min, compact_outlier_count_max);
-  result->noisy_top_count = generate_uniform_noise(
-      flattening_seed, salt, "top", g_config.top_count_min, compact_top_count_max);
+  result->noisy_outlier_count =
+      generate_uniform_noise(flattening_seed, salt, "outlier", g_config.outlier_count_min, compact_outlier_count_max);
+  result->noisy_top_count =
+      generate_uniform_noise(flattening_seed, salt, "top", g_config.top_count_min, compact_top_count_max);
 }
 
-CountResult aggregate_count_contributions(
-    seed_t bucket_seed, seed_t aid_seed, const char *salt,
-    uint64 true_count, uint64 distinct_contributors, uint64 unacounted_for,
-    const Contributors *top_contributors)
+CountResult aggregate_count_contributions(seed_t bucket_seed, seed_t aid_seed, const char *salt, uint64 true_count,
+                                          uint64 distinct_contributors, uint64 unacounted_for,
+                                          const Contributors *top_contributors)
 {
   CountResult result = {0};
 
@@ -129,14 +125,9 @@ CountResult aggregate_count_contributions(
 
 static CountResult count_calculate_result(seed_t bucket_seed, const char *salt, const ContributionTrackerState *tracker)
 {
-  return aggregate_count_contributions(
-      bucket_seed,
-      tracker->aid_seed,
-      salt,
-      tracker->overall_contribution.integer,
-      tracker->distinct_contributors,
-      tracker->unaccounted_for,
-      &tracker->top_contributors);
+  return aggregate_count_contributions(bucket_seed, tracker->aid_seed, salt, tracker->overall_contribution.integer,
+                                       tracker->distinct_contributors, tracker->unaccounted_for,
+                                       &tracker->top_contributors);
 }
 
 void accumulate_count_result(CountResultAccumulator *accumulator, const CountResult *result)
@@ -253,8 +244,8 @@ static void count_merge(AnonAggState *dst_base_state, const AnonAggState *src_ba
     while ((entry = ContributionTracker_iterate(src_contribution_tracker->contribution_table, &iterator)) != NULL)
     {
       if (entry->has_contribution)
-        contribution_tracker_update_contribution(
-            dst_contribution_tracker, entry->contributor.aid, entry->contributor.contribution);
+        contribution_tracker_update_contribution(dst_contribution_tracker, entry->contributor.aid,
+                                                 entry->contributor.contribution);
       else
         contribution_tracker_update_aid(dst_contribution_tracker, entry->contributor.aid);
     }

--- a/src/aggregation/count_distinct.c
+++ b/src/aggregation/count_distinct.c
@@ -43,8 +43,7 @@ typedef struct DistinctTrackerData
 static const int VALUE_INDEX = 1;
 static const int AIDS_OFFSET = 2;
 
-static DistinctTrackerHashEntry *
-get_distinct_tracker_entry(DistinctTracker_hash *tracker, Datum value, int aids_count)
+static DistinctTrackerHashEntry *get_distinct_tracker_entry(DistinctTracker_hash *tracker, Datum value, int aids_count)
 {
   bool found = false;
   DistinctTrackerHashEntry *entry = DistinctTracker_insert(tracker, value, &found);
@@ -262,9 +261,7 @@ static void distribute_lc_values(List *per_aid_values, uint32 values_count)
 }
 
 /* Computes the aid seed, total count of contributors and fills the top contributors array. */
-static void process_lc_values_contributions(List *per_aid_values,
-                                            seed_t *aid_seed,
-                                            uint64 *contributors_count,
+static void process_lc_values_contributions(List *per_aid_values, seed_t *aid_seed, uint64 *contributors_count,
                                             Contributors *top_contributors)
 {
   *contributors_count = 0;
@@ -302,11 +299,8 @@ typedef struct CountDistinctResult
  * The number of high count values is safe to be shown directly, without any extra noise.
  * The number of low count values has to be anonymized.
  */
-static CountDistinctResult count_distinct_calculate_final(
-    CountDistinctState *state,
-    seed_t bucket_seed,
-    const char *salt,
-    int64 min_count)
+static CountDistinctResult count_distinct_calculate_final(CountDistinctState *state, seed_t bucket_seed,
+                                                          const char *salt, int64 min_count)
 {
   int aids_count = state->args_desc->num_args - AIDS_OFFSET;
   set_value_sorting_globals(state->args_desc->args[VALUE_INDEX].type_oid);
@@ -338,15 +332,11 @@ static CountDistinctResult count_distinct_calculate_final(
 
     seed_t aid_seed = 0;
     uint64 contributors_count = 0;
-    process_lc_values_contributions(
-        per_aid_values,
-        &aid_seed, &contributors_count,
-        top_contributors);
+    process_lc_values_contributions(per_aid_values, &aid_seed, &contributors_count, top_contributors);
 
     uint64 unaccounted_for = 0;
     CountResult inner_count_result = aggregate_count_contributions(
-        bucket_seed, aid_seed, salt, lc_values_true_count,
-        contributors_count, unaccounted_for, top_contributors);
+        bucket_seed, aid_seed, salt, lc_values_true_count, contributors_count, unaccounted_for, top_contributors);
 
     list_free_deep(per_aid_values);
     pfree(top_contributors);
@@ -406,14 +396,16 @@ static AnonAggState *count_distinct_create_state(MemoryContext memory_context, A
   return &state->base;
 }
 
-static Datum count_distinct_finalize(AnonAggState *base_state, Bucket *bucket, BucketDescriptor *bucket_desc, bool *is_null)
+static Datum count_distinct_finalize(AnonAggState *base_state, Bucket *bucket, BucketDescriptor *bucket_desc,
+                                     bool *is_null)
 {
   CountDistinctState *state = (CountDistinctState *)base_state;
 
   seed_t bucket_seed = compute_bucket_seed(bucket, bucket_desc);
   bool is_global = bucket_desc->num_labels == 0;
   int64 min_count = is_global ? 0 : g_config.low_count_min_threshold;
-  CountDistinctResult result = count_distinct_calculate_final(state, bucket_seed, bucket_desc->anon_context->salt, min_count);
+  CountDistinctResult result =
+      count_distinct_calculate_final(state, bucket_seed, bucket_desc->anon_context->salt, min_count);
   return Int64GetDatum(result.noisy_count);
 }
 
@@ -436,8 +428,7 @@ static void count_distinct_merge(AnonAggState *dst_base_state, const AnonAggStat
   DistinctTrackerHashEntry *src_entry = NULL;
   while ((src_entry = DistinctTracker_iterate(src_state->tracker, &src_iterator)) != NULL)
   {
-    DistinctTrackerHashEntry *dst_entry =
-        get_distinct_tracker_entry(dst_state->tracker, src_entry->value, aids_count);
+    DistinctTrackerHashEntry *dst_entry = get_distinct_tracker_entry(dst_state->tracker, src_entry->value, aids_count);
 
     ListCell *dst_cell = NULL;
     const ListCell *src_cell = NULL;

--- a/src/aggregation/led.c
+++ b/src/aggregation/led.c
@@ -68,11 +68,9 @@ static inline uint32 subset_hash(SiblingsTrackerData *data, BucketRef bucket)
     if (i == skipped_column)
       continue;
 
-    uint32 label_hash = bucket->is_null[i]
-                            ? 0
-                            : (uint32)hash_datum(bucket->values[i],
-                                                 bucket_desc->attrs[i].typ_byval,
-                                                 bucket_desc->attrs[i].typ_len);
+    uint32 label_hash = bucket->is_null[i] ? 0
+                                           : (uint32)hash_datum(bucket->values[i], bucket_desc->attrs[i].typ_byval,
+                                                                bucket_desc->attrs[i].typ_len);
     hash ^= label_hash;
   }
 
@@ -137,7 +135,8 @@ void led_hook(List *buckets, BucketDescriptor *bucket_desc)
   if (num_labels <= 2)
     return;
 
-  MemoryContext led_context = AllocSetContextCreate(bucket_desc->bucket_context, "led_hook context", ALLOCSET_DEFAULT_SIZES);
+  MemoryContext led_context =
+      AllocSetContextCreate(bucket_desc->bucket_context, "led_hook context", ALLOCSET_DEFAULT_SIZES);
   MemoryContext temp_context = AllocSetContextCreate(led_context, "led_hook temporary context", ALLOCSET_DEFAULT_SIZES);
 
   MemoryContext old_context = MemoryContextSwitchTo(temp_context);
@@ -161,9 +160,8 @@ void led_hook(List *buckets, BucketDescriptor *bucket_desc)
    * if we have 3 columns (c), then for each bucket (b) we have:
    * [ b0c0, b0c1, b0c2, b1c0, b1c1, b1c2, b2c0 ... ]
    */
-  BucketSiblings **bucket_siblings = MemoryContextAllocZero(
-      led_context,
-      num_buckets * num_labels * sizeof(BucketSiblings *));
+  BucketSiblings **bucket_siblings =
+      MemoryContextAllocZero(led_context, num_buckets * num_labels * sizeof(BucketSiblings *));
 
   /* Fill hash table & associate siblings. Skip star bucket (bucket #0). */
   for (int bucket_idx = 1; bucket_idx < num_buckets; bucket_idx++)
@@ -219,9 +217,7 @@ void led_hook(List *buckets, BucketDescriptor *bucket_desc)
          * Single sibling (self+other). Find it and check if it's high count.
          * A column with a single high-count sibling is an isolating column.
          */
-        BucketRef other_bucket = (siblings->values[0] == bucket)
-                                     ? (siblings->values[1])
-                                     : (siblings->values[0]);
+        BucketRef other_bucket = (siblings->values[0] == bucket) ? (siblings->values[1]) : (siblings->values[0]);
         if (!other_bucket->low_count)
           merge_targets[isolating_columns++] = other_bucket;
       }

--- a/src/aggregation/noise.c
+++ b/src/aggregation/noise.c
@@ -103,8 +103,8 @@ static double generate_normal_noise(seed_t seed, const char *salt, const char *s
   return sd * normal;
 }
 
-double generate_layered_noise(const seed_t *seeds, int seeds_count,
-                              const char *salt, const char *step_name, double layer_sd)
+double generate_layered_noise(const seed_t *seeds, int seeds_count, const char *salt, const char *step_name,
+                              double layer_sd)
 {
   double noise = 0;
   for (int i = 0; i < seeds_count; i++)
@@ -112,11 +112,10 @@ double generate_layered_noise(const seed_t *seeds, int seeds_count,
   return noise;
 }
 
-int generate_lcf_threshold(const seed_t *seeds, int seeds_count,
-                           const char *salt)
+int generate_lcf_threshold(const seed_t *seeds, int seeds_count, const char *salt)
 {
-  double threshold_mean = (double)g_config.low_count_min_threshold +
-                          g_config.low_count_mean_gap * g_config.low_count_layer_sd;
+  double threshold_mean =
+      (double)g_config.low_count_min_threshold + g_config.low_count_mean_gap * g_config.low_count_layer_sd;
   double noise = generate_layered_noise(seeds, seeds_count, salt, "suppress", g_config.low_count_layer_sd);
   int noisy_threshold = (int)(threshold_mean + noise);
   return Max(noisy_threshold, g_config.low_count_min_threshold);

--- a/src/aggregation/star_bucket.c
+++ b/src/aggregation/star_bucket.c
@@ -32,7 +32,8 @@ static void set_text_label(Bucket *star_bucket, int att_idx, Oid type, MemoryCon
 Bucket *star_bucket_hook(List *buckets, BucketDescriptor *bucket_desc)
 {
   MemoryContext bucket_context = bucket_desc->bucket_context;
-  MemoryContext temp_context = AllocSetContextCreate(bucket_context, "star_bucket_hook temporary context", ALLOCSET_DEFAULT_SIZES);
+  MemoryContext temp_context =
+      AllocSetContextCreate(bucket_context, "star_bucket_hook temporary context", ALLOCSET_DEFAULT_SIZES);
 
   MemoryContext old_context = MemoryContextSwitchTo(temp_context);
 
@@ -47,7 +48,8 @@ Bucket *star_bucket_hook(List *buckets, BucketDescriptor *bucket_desc)
     BucketAttribute *att = &bucket_desc->attrs[i];
     if (att->tag == BUCKET_ANON_AGG)
       /* Create an empty anon agg state and merge buckets into it. */
-      star_bucket->values[i] = PointerGetDatum(create_anon_agg_state(att->agg.funcs, bucket_context, att->agg.args_desc));
+      star_bucket->values[i] =
+          PointerGetDatum(create_anon_agg_state(att->agg.funcs, bucket_context, att->agg.args_desc));
     else if (att->tag == BUCKET_LABEL)
       set_text_label(star_bucket, i, att->final_type, bucket_context);
     else if (att->agg.fn_oid == g_oid_cache.is_suppress_bin)

--- a/src/auth.c
+++ b/src/auth.c
@@ -77,7 +77,7 @@ static inline bool is_direct_label(const char *seclabel)
   return strcasecmp(seclabel, "direct") == 0;
 }
 
-#define FAIL_ON_INVALID_LABEL(seclabel) \
+#define FAIL_ON_INVALID_LABEL(seclabel)                                                                                \
   FAILWITH_CODE(ERRCODE_INVALID_NAME, "'%s' is not a valid anonymization label", seclabel);
 
 AccessLevel get_user_access_level(void)
@@ -158,11 +158,9 @@ bool is_aid_column(Oid relation_oid, AttrNumber attnum)
     FAIL_ON_INVALID_LABEL(seclabel);
 }
 
-#define FAIL_ON_INVALID_OBJECT_TYPE(seclabel, object)                   \
-  FAILWITH_CODE(                                                        \
-      ERRCODE_FEATURE_NOT_SUPPORTED,                                    \
-      "Anonymization label `%s` not supported on objects of type `%s`", \
-      seclabel, getObjectTypeDescription(object))
+#define FAIL_ON_INVALID_OBJECT_TYPE(seclabel, object)                                                                  \
+  FAILWITH_CODE(ERRCODE_FEATURE_NOT_SUPPORTED, "Anonymization label `%s` not supported on objects of type `%s`",       \
+                seclabel, getObjectTypeDescription(object))
 
 static void verify_pg_features(Oid relation_id)
 {

--- a/src/config.c
+++ b/src/config.c
@@ -77,7 +77,8 @@ static bool outlier_count_min_check_hook(int *newval, void **extra, GucSource so
 {
   if (source >= PGC_S_INTERACTIVE && *newval > g_config.outlier_count_max)
   {
-    NOTICE_LOG("Outlier count interval invalid: (%d, %d). Set upper bound to make it valid.", *newval, g_config.outlier_count_max);
+    NOTICE_LOG("Outlier count interval invalid: (%d, %d). Set upper bound to make it valid.", *newval,
+               g_config.outlier_count_max);
   }
   return true;
 }
@@ -86,7 +87,8 @@ static bool outlier_count_max_check_hook(int *newval, void **extra, GucSource so
 {
   if (source >= PGC_S_INTERACTIVE && *newval < g_config.outlier_count_min)
   {
-    NOTICE_LOG("Outlier count interval invalid: (%d, %d). Set lower bound to make it valid.", g_config.outlier_count_min, *newval);
+    NOTICE_LOG("Outlier count interval invalid: (%d, %d). Set lower bound to make it valid.",
+               g_config.outlier_count_min, *newval);
   }
   return true;
 }
@@ -95,7 +97,8 @@ static bool top_count_min_check_hook(int *newval, void **extra, GucSource source
 {
   if (source >= PGC_S_INTERACTIVE && *newval > g_config.top_count_max)
   {
-    NOTICE_LOG("Top count interval invalid: (%d, %d). Set upper bound to make it valid.", *newval, g_config.top_count_max);
+    NOTICE_LOG("Top count interval invalid: (%d, %d). Set upper bound to make it valid.", *newval,
+               g_config.top_count_max);
   }
   return true;
 }
@@ -104,7 +107,8 @@ static bool top_count_max_check_hook(int *newval, void **extra, GucSource source
 {
   if (source >= PGC_S_INTERACTIVE && *newval < g_config.top_count_min)
   {
-    NOTICE_LOG("Top count interval invalid: (%d, %d). Set lower bound to make it valid.", g_config.top_count_min, *newval);
+    NOTICE_LOG("Top count interval invalid: (%d, %d). Set lower bound to make it valid.", g_config.top_count_min,
+               *newval);
   }
   return true;
 }
@@ -113,74 +117,69 @@ void config_init(void)
 {
   g_initializing = true;
 
-  DefineCustomEnumVariable(
-      "pg_diffix.session_access_level",    /* name */
-      "Access level for current session.", /* short_desc */
-      NULL,                                /* long_desc */
-      &g_config.session_access_level,      /* valueAddr */
-      ACCESS_DIRECT,                       /* bootValue */
-      access_level_options,                /* options */
-      PGC_USERSET,                         /* context */
-      0,                                   /* flags */
-      session_access_level_check,          /* check_hook */
-      NULL,                                /* assign_hook */
-      NULL);                               /* show_hook */
+  DefineCustomEnumVariable("pg_diffix.session_access_level",    /* name */
+                           "Access level for current session.", /* short_desc */
+                           NULL,                                /* long_desc */
+                           &g_config.session_access_level,      /* valueAddr */
+                           ACCESS_DIRECT,                       /* bootValue */
+                           access_level_options,                /* options */
+                           PGC_USERSET,                         /* context */
+                           0,                                   /* flags */
+                           session_access_level_check,          /* check_hook */
+                           NULL,                                /* assign_hook */
+                           NULL);                               /* show_hook */
 
-  DefineCustomEnumVariable(
-      "pg_diffix.default_access_level",    /* name */
-      "Access level for unlabeled users.", /* short_desc */
-      NULL,                                /* long_desc */
-      &g_config.default_access_level,      /* valueAddr */
-      ACCESS_DIRECT,                       /* bootValue */
-      access_level_options,                /* options */
-      PGC_SUSET,                           /* context */
-      0,                                   /* flags */
-      NULL,                                /* check_hook */
-      NULL,                                /* assign_hook */
-      NULL);                               /* show_hook */
+  DefineCustomEnumVariable("pg_diffix.default_access_level",    /* name */
+                           "Access level for unlabeled users.", /* short_desc */
+                           NULL,                                /* long_desc */
+                           &g_config.default_access_level,      /* valueAddr */
+                           ACCESS_DIRECT,                       /* bootValue */
+                           access_level_options,                /* options */
+                           PGC_SUSET,                           /* context */
+                           0,                                   /* flags */
+                           NULL,                                /* check_hook */
+                           NULL,                                /* assign_hook */
+                           NULL);                               /* show_hook */
 
-  DefineCustomRealVariable(
-      "pg_diffix.noise_layer_sd",                                     /* name */
-      "Standard deviation for each noise layer added to aggregates.", /* short_desc */
-      NULL,                                                           /* long_desc */
-      &g_config.noise_layer_sd,                                       /* valueAddr */
-      1.0,                                                            /* bootValue */
-      0,                                                              /* minValue */
-      MAX_NUMERIC_CONFIG,                                             /* maxValue */
-      PGC_SUSET,                                                      /* context */
-      0,                                                              /* flags */
-      NULL,                                                           /* check_hook */
-      NULL,                                                           /* assign_hook */
-      NULL);                                                          /* show_hook */
+  DefineCustomRealVariable("pg_diffix.noise_layer_sd",                                     /* name */
+                           "Standard deviation for each noise layer added to aggregates.", /* short_desc */
+                           NULL,                                                           /* long_desc */
+                           &g_config.noise_layer_sd,                                       /* valueAddr */
+                           1.0,                                                            /* bootValue */
+                           0,                                                              /* minValue */
+                           MAX_NUMERIC_CONFIG,                                             /* maxValue */
+                           PGC_SUSET,                                                      /* context */
+                           0,                                                              /* flags */
+                           NULL,                                                           /* check_hook */
+                           NULL,                                                           /* assign_hook */
+                           NULL);                                                          /* show_hook */
 
-  DefineCustomIntVariable(
-      "pg_diffix.low_count_min_threshold",              /* name */
-      "Lower bound of the low count filter threshold.", /* short_desc */
-      NULL,                                             /* long_desc */
-      &g_config.low_count_min_threshold,                /* valueAddr */
-      2,                                                /* bootValue */
-      2,                                                /* minValue */
-      MAX_NUMERIC_CONFIG,                               /* maxValue */
-      PGC_SUSET,                                        /* context */
-      0,                                                /* flags */
-      NULL,                                             /* check_hook */
-      NULL,                                             /* assign_hook */
-      NULL);                                            /* show_hook */
+  DefineCustomIntVariable("pg_diffix.low_count_min_threshold",              /* name */
+                          "Lower bound of the low count filter threshold.", /* short_desc */
+                          NULL,                                             /* long_desc */
+                          &g_config.low_count_min_threshold,                /* valueAddr */
+                          2,                                                /* bootValue */
+                          2,                                                /* minValue */
+                          MAX_NUMERIC_CONFIG,                               /* maxValue */
+                          PGC_SUSET,                                        /* context */
+                          0,                                                /* flags */
+                          NULL,                                             /* check_hook */
+                          NULL,                                             /* assign_hook */
+                          NULL);                                            /* show_hook */
 
-  DefineCustomRealVariable(
-      "pg_diffix.low_count_mean_gap",             /* name */
-      "Number of standard deviations between the lower bound \
-and the mean of the low count filter threshold.", /* short_desc */
-      NULL,                                       /* long_desc */
-      &g_config.low_count_mean_gap,               /* valueAddr */
-      2.0,                                        /* bootValue */
-      0,                                          /* minValue */
-      MAX_NUMERIC_CONFIG,                         /* maxValue */
-      PGC_SUSET,                                  /* context */
-      0,                                          /* flags */
-      NULL,                                       /* check_hook */
-      NULL,                                       /* assign_hook */
-      NULL);                                      /* show_hook */
+  DefineCustomRealVariable("pg_diffix.low_count_mean_gap", /* name */
+                           "Number of standard deviations between the lower bound \
+and the mean of the low count filter threshold.",          /* short_desc */
+                           NULL,                           /* long_desc */
+                           &g_config.low_count_mean_gap,   /* valueAddr */
+                           2.0,                            /* bootValue */
+                           0,                              /* minValue */
+                           MAX_NUMERIC_CONFIG,             /* maxValue */
+                           PGC_SUSET,                      /* context */
+                           0,                              /* flags */
+                           NULL,                           /* check_hook */
+                           NULL,                           /* assign_hook */
+                           NULL);                          /* show_hook */
 
   DefineCustomRealVariable(
       "pg_diffix.low_count_layer_sd",                                               /* name */
@@ -196,61 +195,57 @@ and the mean of the low count filter threshold.", /* short_desc */
       NULL,                                                                         /* assign_hook */
       NULL);                                                                        /* show_hook */
 
-  DefineCustomIntVariable(
-      "pg_diffix.outlier_count_min",                 /* name */
-      "Minimum outlier count (inclusive).",          /* short_desc */
-      "Must not be greater than outlier_count_max.", /* long_desc */
-      &g_config.outlier_count_min,                   /* valueAddr */
-      1,                                             /* bootValue */
-      0,                                             /* minValue */
-      MAX_NUMERIC_CONFIG,                            /* maxValue */
-      PGC_SUSET,                                     /* context */
-      0,                                             /* flags */
-      &outlier_count_min_check_hook,                 /* check_hook */
-      NULL,                                          /* assign_hook */
-      NULL);                                         /* show_hook */
+  DefineCustomIntVariable("pg_diffix.outlier_count_min",                 /* name */
+                          "Minimum outlier count (inclusive).",          /* short_desc */
+                          "Must not be greater than outlier_count_max.", /* long_desc */
+                          &g_config.outlier_count_min,                   /* valueAddr */
+                          1,                                             /* bootValue */
+                          0,                                             /* minValue */
+                          MAX_NUMERIC_CONFIG,                            /* maxValue */
+                          PGC_SUSET,                                     /* context */
+                          0,                                             /* flags */
+                          &outlier_count_min_check_hook,                 /* check_hook */
+                          NULL,                                          /* assign_hook */
+                          NULL);                                         /* show_hook */
 
-  DefineCustomIntVariable(
-      "pg_diffix.outlier_count_max",                 /* name */
-      "Maximum outlier count (inclusive).",          /* short_desc */
-      "Must not be smaller than outlier_count_min.", /* long_desc */
-      &g_config.outlier_count_max,                   /* valueAddr */
-      2,                                             /* bootValue */
-      0,                                             /* minValue */
-      MAX_NUMERIC_CONFIG,                            /* maxValue */
-      PGC_SUSET,                                     /* context */
-      0,                                             /* flags */
-      &outlier_count_max_check_hook,                 /* check_hook */
-      NULL,                                          /* assign_hook */
-      NULL);                                         /* show_hook */
+  DefineCustomIntVariable("pg_diffix.outlier_count_max",                 /* name */
+                          "Maximum outlier count (inclusive).",          /* short_desc */
+                          "Must not be smaller than outlier_count_min.", /* long_desc */
+                          &g_config.outlier_count_max,                   /* valueAddr */
+                          2,                                             /* bootValue */
+                          0,                                             /* minValue */
+                          MAX_NUMERIC_CONFIG,                            /* maxValue */
+                          PGC_SUSET,                                     /* context */
+                          0,                                             /* flags */
+                          &outlier_count_max_check_hook,                 /* check_hook */
+                          NULL,                                          /* assign_hook */
+                          NULL);                                         /* show_hook */
 
-  DefineCustomIntVariable(
-      "pg_diffix.top_count_min",                     /* name */
-      "Minimum top contributors count (inclusive).", /* short_desc */
-      "Must not be greater than top_count_max.",     /* long_desc */
-      &g_config.top_count_min,                       /* valueAddr */
-      4,                                             /* bootValue */
-      1,                                             /* minValue */
-      MAX_NUMERIC_CONFIG,                            /* maxValue */
-      PGC_SUSET,                                     /* context */
-      0,                                             /* flags */
-      &top_count_min_check_hook,                     /* check_hook */
-      NULL,                                          /* assign_hook */
-      NULL);                                         /* show_hook */
+  DefineCustomIntVariable("pg_diffix.top_count_min",                     /* name */
+                          "Minimum top contributors count (inclusive).", /* short_desc */
+                          "Must not be greater than top_count_max.",     /* long_desc */
+                          &g_config.top_count_min,                       /* valueAddr */
+                          4,                                             /* bootValue */
+                          1,                                             /* minValue */
+                          MAX_NUMERIC_CONFIG,                            /* maxValue */
+                          PGC_SUSET,                                     /* context */
+                          0,                                             /* flags */
+                          &top_count_min_check_hook,                     /* check_hook */
+                          NULL,                                          /* assign_hook */
+                          NULL);                                         /* show_hook */
 
-  DefineCustomIntVariable(
-      "pg_diffix.top_count_max",                     /* name */
-      "Maximum top contributors count (inclusive).", /* short_desc */
-      "Must not be smaller than top_count_min.",     /* long_desc */
-      &g_config.top_count_max,                       /* valueAddr */
-      6,                                             /* bootValue */
-      1,                                             /* minValue */
-      MAX_NUMERIC_CONFIG,                            /* maxValue */
-      PGC_SUSET,                                     /* context */
-      0,                                             /* flags */
-      &top_count_max_check_hook,                     /* check_hook */
-      NULL,                                          /* assign_hook */
-      NULL);                                         /* show_hook */
+  DefineCustomIntVariable("pg_diffix.top_count_max",                     /* name */
+                          "Maximum top contributors count (inclusive).", /* short_desc */
+                          "Must not be smaller than top_count_min.",     /* long_desc */
+                          &g_config.top_count_max,                       /* valueAddr */
+                          6,                                             /* bootValue */
+                          1,                                             /* minValue */
+                          MAX_NUMERIC_CONFIG,                            /* maxValue */
+                          PGC_SUSET,                                     /* context */
+                          0,                                             /* flags */
+                          &top_count_max_check_hook,                     /* check_hook */
+                          NULL,                                          /* assign_hook */
+                          NULL);                                         /* show_hook */
 
   DefineCustomBoolVariable(
       "pg_diffix.compute_suppress_bin",                                                 /* name */

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -59,7 +59,8 @@ static AnonQueryLinks *prepare_query(Query *query)
     return NULL;
 
   /* At this point we have an anonymizing query. */
-  DEBUG_LOG("Anonymizing query (Query ID=%lu) (User ID=%u) %s", query->queryId, GetSessionUserId(), nodeToString(query));
+  DEBUG_LOG("Anonymizing query (Query ID=%lu) (User ID=%u) %s", query->queryId, GetSessionUserId(),
+            nodeToString(query));
 
   /* We load OIDs lazily because experimentation shows that UDFs may return INVALIDOID (0) during _PG_init. */
   oid_cache_init();
@@ -77,11 +78,8 @@ static AnonQueryLinks *prepare_query(Query *query)
   return links;
 }
 
-static PlannedStmt *pg_diffix_planner(
-    Query *query,
-    const char *query_string,
-    int cursorOptions,
-    ParamListInfo boundParams)
+static PlannedStmt *pg_diffix_planner(Query *query, const char *query_string, int cursorOptions,
+                                      ParamListInfo boundParams)
 {
   static uint64 next_query_id = 1;
   query->queryId = next_query_id++;
@@ -132,12 +130,9 @@ static void prepare_utility(PlannedStmt *pstmt)
 }
 
 #if PG_MAJORVERSION_NUM == 13
-static void pg_diffix_ProcessUtility(PlannedStmt *pstmt,
-                                     const char *queryString,
-                                     ProcessUtilityContext context,
-                                     ParamListInfo params,
-                                     QueryEnvironment *queryEnv,
-                                     DestReceiver *dest, QueryCompletion *qc)
+static void pg_diffix_ProcessUtility(PlannedStmt *pstmt, const char *queryString, ProcessUtilityContext context,
+                                     ParamListInfo params, QueryEnvironment *queryEnv, DestReceiver *dest,
+                                     QueryCompletion *qc)
 {
   prepare_utility(pstmt);
   if (prev_ProcessUtility_hook)
@@ -146,12 +141,8 @@ static void pg_diffix_ProcessUtility(PlannedStmt *pstmt,
     standard_ProcessUtility(pstmt, queryString, context, params, queryEnv, dest, qc);
 }
 #else
-static void pg_diffix_ProcessUtility(PlannedStmt *pstmt,
-                                     const char *queryString,
-                                     bool readOnlyTree,
-                                     ProcessUtilityContext context,
-                                     ParamListInfo params,
-                                     QueryEnvironment *queryEnv,
+static void pg_diffix_ProcessUtility(PlannedStmt *pstmt, const char *queryString, bool readOnlyTree,
+                                     ProcessUtilityContext context, ParamListInfo params, QueryEnvironment *queryEnv,
                                      DestReceiver *dest, QueryCompletion *qc)
 {
   prepare_utility(pstmt);
@@ -188,11 +179,7 @@ static bool pg_diffix_ExecutorCheckPerms(List *range_tables, bool should_abort)
   return true;
 }
 
-static void pg_diffix_ExecutorRun(
-    QueryDesc *queryDesc,
-    ScanDirection direction,
-    uint64 count,
-    bool execute_once)
+static void pg_diffix_ExecutorRun(QueryDesc *queryDesc, ScanDirection direction, uint64 count, bool execute_once)
 {
   if (prev_ExecutorRun_hook)
     prev_ExecutorRun_hook(queryDesc, direction, count, execute_once);

--- a/src/query/allowed_functions.c
+++ b/src/query/allowed_functions.c
@@ -7,10 +7,8 @@
 #include "pg_diffix/utils.h"
 
 static const char *const g_allowed_casts[] = {
-    "i2tod", "i2tof", "i2toi4", "i4toi2", "i4tod", "i4tof", "i8tod", "i8tof",
-    "ftod", "dtof",
-    "int4_numeric", "float4_numeric", "float8_numeric",
-    "numeric_float4", "numeric_float8",
+    "i2tod", "i2tof", "i2toi4",       "i4toi2",         "i4tod",          "i4tof",          "i8tod",          "i8tof",
+    "ftod",  "dtof",  "int4_numeric", "float4_numeric", "float8_numeric", "numeric_float4", "numeric_float8",
     /**/
 };
 
@@ -42,12 +40,8 @@ static const Oid g_allowed_builtins_extra[] = {F_NUMERIC_ROUND_INT};
 
 /* Pointers to OID cache which is populated at runtime. */
 static const Oid *const g_implicit_range_udfs[] = {
-    &g_oid_cache.round_by_nn,
-    &g_oid_cache.round_by_dd,
-    &g_oid_cache.ceil_by_nn,
-    &g_oid_cache.ceil_by_dd,
-    &g_oid_cache.floor_by_nn,
-    &g_oid_cache.floor_by_dd,
+    &g_oid_cache.round_by_nn, &g_oid_cache.round_by_dd, &g_oid_cache.ceil_by_nn,
+    &g_oid_cache.ceil_by_dd,  &g_oid_cache.floor_by_nn, &g_oid_cache.floor_by_dd,
 };
 
 /* Taken from fmgr.c. */

--- a/src/query/anonymization.c
+++ b/src/query/anonymization.c
@@ -189,13 +189,8 @@ static Node *aggregate_expression_mutator(Node *node, List *aid_refs)
 
 static Expr *make_aid_expr(AidRef *aid_ref)
 {
-  return (Expr *)makeVar(
-      aid_ref->rte_index,
-      aid_ref->aid_attnum,
-      aid_ref->aid_column->atttype,
-      aid_ref->aid_column->typmod,
-      aid_ref->aid_column->collid,
-      0);
+  return (Expr *)makeVar(aid_ref->rte_index, aid_ref->aid_attnum, aid_ref->aid_column->atttype,
+                         aid_ref->aid_column->typmod, aid_ref->aid_column->collid, 0);
 }
 
 static TargetEntry *make_aid_target(AidRef *aid_ref, AttrNumber resno, bool resjunk)
@@ -224,11 +219,8 @@ static SensitiveRelation *find_relation(Oid rel_oid, List *relations)
 /*
  * Adds references targeting AIDs of relation to `aid_refs`.
  */
-static void gather_relation_aids(
-    const SensitiveRelation *relation,
-    Index rte_index,
-    RangeTblEntry *rte,
-    List **aid_refs)
+static void gather_relation_aids(const SensitiveRelation *relation, Index rte_index, RangeTblEntry *rte,
+                                 List **aid_refs)
 {
   ListCell *cell;
   foreach (cell, relation->aid_columns)
@@ -244,8 +236,7 @@ static void gather_relation_aids(
     *aid_refs = lappend(*aid_refs, aid_ref);
 
     /* Emulate what the parser does */
-    rte->selectedCols = bms_add_member(
-        rte->selectedCols, aid_col->attnum - FirstLowInvalidHeapAttributeNumber);
+    rte->selectedCols = bms_add_member(rte->selectedCols, aid_col->attnum - FirstLowInvalidHeapAttributeNumber);
   }
 }
 
@@ -299,8 +290,7 @@ static void append_aid_args(Aggref *aggref, List *aid_refs)
 
 #define MAX_SEED_MATERIAL_SIZE 1024 /* Fixed max size, to avoid dynamic allocation. */
 
-static void append_seed_material(
-    char *existing_material, const char *new_material, char separator)
+static void append_seed_material(char *existing_material, const char *new_material, char separator)
 {
   size_t existing_material_length = strlen(existing_material);
   size_t new_material_length = strlen(new_material);
@@ -472,11 +462,7 @@ static AnonymizationContext *make_query_anonymizing(Query *query, List *sensitiv
     anon_context->expand_buckets = true;
   }
 
-  query_tree_mutator(
-      query,
-      aggregate_expression_mutator,
-      aid_refs,
-      QTW_DONT_COPY_QUERY);
+  query_tree_mutator(query, aggregate_expression_mutator, aid_refs, QTW_DONT_COPY_QUERY);
 
   /* Global aggregates have to be excluded from low-count filtering. */
   if (initial_has_group_clause || (!initial_has_aggs && !initial_all_targets_constant))


### PR DESCRIPTION
I'm by no means saying we should do this, but just to show the effect. Motivation: I missed a line becoming too long once or twice.

But I don't like the new style that much, not sure if it's worth the uprooting. I also haven't dug through all the options of `clang-formatter`.