### PR TITLE
Drop unused `salt` field from config.

### DIFF
--- a/pg_diffix/config.h
+++ b/pg_diffix/config.h
@@ -9,8 +9,6 @@ typedef struct DiffixConfig
   int default_access_level;
   int session_access_level;
 
-  char *salt;
-
   double noise_layer_sd;
 
   int low_count_min_threshold;

--- a/src/config.c
+++ b/src/config.c
@@ -30,7 +30,6 @@ static char *config_to_string(DiffixConfig *config)
 
   appendStringInfo(&string, " :default_access_level %i", config->default_access_level);
   appendStringInfo(&string, " :session_access_level %i", config->session_access_level);
-  appendStringInfo(&string, " :salt \"%s\"", config->salt);
   appendStringInfo(&string, " :noise_layer_sd %f", config->noise_layer_sd);
   appendStringInfo(&string, " :low_count_min_threshold %i", config->low_count_min_threshold);
   appendStringInfo(&string, " :low_count_mean_gap %f", config->low_count_mean_gap);


### PR DESCRIPTION
This was crashing the extension during load.