### PR TITLE
Rewrite anon agg final type later in bucketscan

### DIFF
--- a/src/aggregation/bucket_scan.c
+++ b/src/aggregation/bucket_scan.c
@@ -519,7 +519,6 @@ static bool gather_aggrefs_walker(Node *node, List **aggrefs)
 /*
  * Returns a new target list for Agg without any projections.
  * First entries are grouping labels, followed by aggregate expressions.
- * Anonymizing aggregators are updated to have AnonAggState return type.
  */
 static List *flatten_agg_tlist(Agg *agg, AttrNumber *grouping_cols, int num_labels)
 {
@@ -565,14 +564,6 @@ static List *flatten_agg_tlist(Agg *agg, AttrNumber *grouping_cols, int num_labe
   for (int i = 0; i < num_aggrefs; i++)
   {
     Aggref *aggref = list_nth_node(Aggref, aggrefs, i);
-
-    if (is_anonymizing_agg(aggref->aggfnoid))
-    {
-      /* Convert to AnonAggState because rewriter has left original aggregate types. */
-      aggref->aggtype = g_oid_cache.anon_agg_state;
-      aggref->aggcollid = 0;
-    }
-
     TargetEntry *agg_target_entry = makeTargetEntry((Expr *)aggref, num_labels + i + 1, NULL, false);
     TargetEntry *orig_target_entry = tlist_member((Expr *)aggref, orig_agg_tlist);
 
@@ -691,6 +682,7 @@ static int find_agg_index(List *tlist, Oid fnoid)
 /*
  * Builds a tlist describing the scan slot. Attributes match with the child tlist,
  * except for anonymized aggregates, which are finalized at this stage.
+ * Anonymized aggregates of Agg are updated to have AnonAggState return type.
  */
 static List *make_scan_tlist(List *flat_agg_tlist, int num_labels, int num_aggs)
 {
@@ -704,10 +696,16 @@ static List *make_scan_tlist(List *flat_agg_tlist, int num_labels, int num_aggs)
 
     if (i >= num_labels)
     {
-      /* If it's an anonymized aggregate, store final type. */
-      const AnonAggFuncs *agg_funcs = find_agg_funcs(castNode(Aggref, agg_tle->expr)->aggfnoid);
+      Aggref *aggref = castNode(Aggref, agg_tle->expr);
+      const AnonAggFuncs *agg_funcs = find_agg_funcs(aggref->aggfnoid);
       if (agg_funcs != NULL)
+      {
+        /* In index slot's entry we store final type. */
         agg_funcs->final_type(&var->vartype, &var->vartypmod, &var->varcollid);
+        /* In Agg's entry we hold the intermediate AnonAggState. */
+        aggref->aggtype = g_oid_cache.anon_agg_state;
+        aggref->aggcollid = 0;
+      }
     }
 
     TargetEntry *scan_tle = makeTargetEntry((Expr *)var, i + 1, agg_tle->resname, false);

--- a/test/expected/misc.out
+++ b/test/expected/misc.out
@@ -55,6 +55,13 @@ SELECT count(*), city FROM test_customers GROUP BY city;
     10 | Berlin
 (3 rows)
 
+-- Same aggregate can be selected multiple times
+SELECT count(*), count(*) FROM test_customers;
+ count | count 
+-------+-------
+    16 |    16
+(1 row)
+
 -- Get rejected because of disallowed utility statement
 COPY test_customers TO STDOUT;
 ERROR:  [PG_DIFFIX] Statement requires either SUPERUSER or direct access level.

--- a/test/sql/misc.sql
+++ b/test/sql/misc.sql
@@ -38,6 +38,9 @@ $$;
 SELECT city, count(*) FROM test_customers GROUP BY city;
 SELECT count(*), city FROM test_customers GROUP BY city;
 
+-- Same aggregate can be selected multiple times
+SELECT count(*), count(*) FROM test_customers;
+
 -- Get rejected because of disallowed utility statement
 COPY test_customers TO STDOUT;
 ALTER TABLE test_customers DROP COLUMN id;


### PR DESCRIPTION
The final type was being rewritten in child entry before lifting projections, and the deduplication failed because of that.