### PR TITLE
Support some postgresql clients

### DIFF
--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -421,7 +421,14 @@ static bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selecte
 {
   char *rel_name = get_rel_name(relation_oid);
 
-  /* First check if the entire relation is allowed. */
+  /* First handle `SELECT count(*) FROM pg_catalog.x`. */
+  if (selected_cols == NULL)
+  {
+    pfree(rel_name);
+    return true;
+  }
+
+  /* Then check if the entire relation is allowed. */
   for (int i = 0; i < ARRAY_LENGTH(g_pg_catalog_allowed_rels); i++)
   {
     if (strcmp(g_pg_catalog_allowed_rels[i], rel_name) == 0)
@@ -429,13 +436,6 @@ static bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selecte
       pfree(rel_name);
       return true;
     }
-  }
-
-  /* Then handle `SELECT count(*) FROM pg_catalog.x`. */
-  if (selected_cols == NULL)
-  {
-    pfree(rel_name);
-    return true;
   }
 
   /* Otherwise specific selected columns must be checked against the allow-list. */


### PR DESCRIPTION
Closes #257 

I did pgAdmin 4 and TablePlus (Linux alpha version). pgAdmin III will pose problems (it requires `pg_seclabel` to start) but is now deprecated.

Any other which you can think of would be worth testing? Nothing in the "best SQL GUI" sounded familiar enough to install and embark on testing.

