### PR TITLE
Optimize memory allocation when handling small buckets.

### DIFF
--- a/src/aggregation/aid_tracker.c
+++ b/src/aggregation/aid_tracker.c
@@ -21,7 +21,7 @@ static AidTrackerState *aid_tracker_new(AidDescriptor aid_descriptor)
   AidTrackerState *state = palloc0(sizeof(AidTrackerState));
 
   state->aid_descriptor = aid_descriptor;
-  state->aid_set = AidTracker_create(CurrentMemoryContext, 128, NULL);
+  state->aid_set = AidTracker_create(CurrentMemoryContext, 4, NULL);
   state->aid_seed = 0;
 
   return state;

--- a/src/aggregation/contribution_tracker.c
+++ b/src/aggregation/contribution_tracker.c
@@ -127,7 +127,7 @@ static ContributionTrackerState *contribution_tracker_new(
 
   state->aid_descriptor = aid_descriptor;
   state->contribution_descriptor = *contribution_descriptor;
-  state->contribution_table = ContributionTracker_create(CurrentMemoryContext, 128, NULL);
+  state->contribution_table = ContributionTracker_create(CurrentMemoryContext, 4, NULL);
   state->aid_seed = 0;
   state->distinct_contributors = 0;
   state->unaccounted_for = 0;

--- a/src/aggregation/count_distinct.c
+++ b/src/aggregation/count_distinct.c
@@ -441,7 +441,7 @@ static AnonAggState *count_distinct_create_state(MemoryContext memory_context, A
   data->typlen = args_desc->args[VALUE_INDEX].typlen;
   data->typbyval = args_desc->args[VALUE_INDEX].typbyval;
 
-  state->tracker = DistinctTracker_create(memory_context, 128, data);
+  state->tracker = DistinctTracker_create(memory_context, 4, data);
   state->args_desc = copy_args_desc(args_desc);
 
   MemoryContextSwitchTo(old_context);


### PR DESCRIPTION
This results in ~30% faster stress tests.