### PR TITLE
Clear is_null from scan slot before finalizing agg

### DIFF
--- a/src/aggregation/bucket_scan.c
+++ b/src/aggregation/bucket_scan.c
@@ -316,6 +316,7 @@ static void finalize_bucket(Bucket *bucket, BucketDescriptor *bucket_desc, ExprC
       AnonAggState *agg_state = (AnonAggState *)DatumGetPointer(bucket->values[i]);
       Assert(agg_state != NULL);
       Assert(agg_state->agg_funcs == att->agg.funcs);
+      is_null[i] = false;
       values[i] = att->agg.funcs->finalize(agg_state, bucket, bucket_desc, &is_null[i]);
     }
     else

--- a/src/aggregation/low_count.c
+++ b/src/aggregation/low_count.c
@@ -91,7 +91,6 @@ static Datum agg_finalize(AnonAggState *base_state, Bucket *bucket, BucketDescri
     low_count = low_count || result.low_count;
   }
 
-  *is_null = false;
   return DatumGetBool(low_count);
 }
 


### PR DESCRIPTION
The fact that we forgot to add it to both `count` and `count_distinct` indicates that it should be opt-in instead of always having to clear it.