### PR TITLE
Minor tweaks part 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM postgres:13 AS builder
 
 RUN set -ex \
   && apt-get update \
-  && apt-get install -y build-essential libssl-dev postgresql-server-dev-13 \
+  && apt-get install -y build-essential libssl-dev postgresql-server-dev-13 jq \
   && mkdir -p /usr/src/pg_diffix
 
 WORKDIR /usr/src/pg_diffix

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -105,10 +105,11 @@ low count filter threshold. Default value is 2.0.
 `pg_diffix.low_count_layer_sd` - The standard deviation for each noise layer used when calculating the low count filter
 threshold. Default value is 1.0.
 
-`pg_diffix.compute_suppress_bin` - If `True`, the first row in the query result might contain the suppress bin, which
-provides the combined anonymized count of all the bins that were suppressed (low count filtered). The suppress bin shows
-all column values as `NULL` (`*` for text-typed columns, customizable via `pg_diffix.text_label_for_suppress_bin`). Note
-that the suppress bin may itself be suppressed.
+`pg_diffix.compute_suppress_bin` - If `True`, some rows in the returned result might belong to the suppress bin,
+combining data of all the suppressed (rejected by the low count filter) protected entities. For an aggregating query,
+the suppress bin will be returned in the first row, while for a non-aggregating query - in multiple initial rows. In
+both cases, these rows have all column values `NULL` (`*` for text-typed columns, customizable via
+`pg_diffix.text_label_for_suppress_bin`). Note that the suppress bin may itself be suppressed and not returned at all.
 
 `pg_diffix.text_label_for_suppress_bin` - The value to use for the text-typed grouping labels in the suppress bin row.
 Default value is `*`.

--- a/pg_diffix/query/allowed_functions.h
+++ b/pg_diffix/query/allowed_functions.h
@@ -1,6 +1,8 @@
 #ifndef PG_DIFFIX_ALLOWED_FUNCTIONS_H
 #define PG_DIFFIX_ALLOWED_FUNCTIONS_H
 
+#include "nodes/bitmapset.h"
+
 /*
  * Returns whether the OID points to a function (or operator) allowed in defining buckets.
  */
@@ -27,5 +29,11 @@ extern bool is_substring_builtin(Oid funcoid);
  * allowed when called in `publish_untrusted` access level.
  */
 extern bool is_implicit_range_builtin_untrusted(Oid funcoid);
+
+/*
+ * Returns whether the OID points to a relation in the `pg_catalog`, for which accessing the
+ * `selected_cols` is allowed.
+ */
+extern bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selected_cols);
 
 #endif /* PG_DIFFIX_ALLOWED_FUNCTIONS_H */

--- a/pg_diffix/query/allowed_objects.h
+++ b/pg_diffix/query/allowed_objects.h
@@ -31,8 +31,7 @@ extern bool is_substring_builtin(Oid funcoid);
 extern bool is_implicit_range_builtin_untrusted(Oid funcoid);
 
 /*
- * Returns whether the OID points to a relation in the `pg_catalog`, for which accessing the
- * `selected_cols` is allowed.
+ * Returns whether selecting `selected_cols` from a relation in the `pg_catalog` is allowed.
  */
 extern bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selected_cols);
 

--- a/pg_diffix/query/allowed_objects.h
+++ b/pg_diffix/query/allowed_objects.h
@@ -1,5 +1,5 @@
-#ifndef PG_DIFFIX_ALLOWED_FUNCTIONS_H
-#define PG_DIFFIX_ALLOWED_FUNCTIONS_H
+#ifndef PG_DIFFIX_ALLOWED_OBJECTS_H
+#define PG_DIFFIX_ALLOWED_OBJECTS_H
 
 #include "nodes/bitmapset.h"
 
@@ -36,4 +36,4 @@ extern bool is_implicit_range_builtin_untrusted(Oid funcoid);
  */
 extern bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selected_cols);
 
-#endif /* PG_DIFFIX_ALLOWED_FUNCTIONS_H */
+#endif /* PG_DIFFIX_ALLOWED_OBJECTS_H */

--- a/src/hooks.c
+++ b/src/hooks.c
@@ -12,7 +12,7 @@
 #include "pg_diffix/config.h"
 #include "pg_diffix/hooks.h"
 #include "pg_diffix/oid_cache.h"
-#include "pg_diffix/query/allowed_functions.h"
+#include "pg_diffix/query/allowed_objects.h"
 #include "pg_diffix/query/anonymization.h"
 #include "pg_diffix/query/relation.h"
 #include "pg_diffix/query/validation.h"

--- a/src/pg_diffix.c
+++ b/src/pg_diffix.c
@@ -7,7 +7,7 @@
 #include "pg_diffix/config.h"
 #include "pg_diffix/hooks.h"
 #include "pg_diffix/oid_cache.h"
-#include "pg_diffix/query/allowed_functions.h"
+#include "pg_diffix/query/allowed_objects.h"
 #include "pg_diffix/utils.h"
 
 #include <limits.h>

--- a/src/query/allowed_functions.c
+++ b/src/query/allowed_functions.c
@@ -1,6 +1,9 @@
 #include "postgres.h"
 
+#include "access/sysattr.h"
 #include "utils/fmgrtab.h"
+#include "utils/lsyscache.h"
+#include "utils/memutils.h"
 
 #include "pg_diffix/oid_cache.h"
 #include "pg_diffix/query/allowed_functions.h"
@@ -40,6 +43,55 @@ static const char *const g_implicit_range_builtins_untrusted[] = {
 /* Some allowed functions don't appear in the builtins catalog, so we must allow them manually by OID. */
 #define F_NUMERIC_ROUND_INT 1708
 static const Oid g_allowed_builtins_extra[] = {F_NUMERIC_ROUND_INT};
+
+typedef struct AllowedCols
+{
+  const char *rel_name;             /* Name of the relation */
+  Bitmapset *cols;                  /* Indices of the allowed columns of the relation */
+  const char *const col_names[100]; /* Names of columns in the relation */
+} AllowedCols;
+
+static const char *const g_pg_catalog_allowed_rels[] = {
+    "pg_aggregate", "pg_am", "pg_attrdef", "pg_attribute", "pg_auth_members", "pg_authid", "pg_available_extension_versions",
+    "pg_available_extensions", "pg_cast", "pg_collation", "pg_constraint", "pg_database", "pg_db_role_setting", "pg_default_acl",
+    "pg_depend", "pg_depend", "pg_description", "pg_event_trigger", "pg_extension", "pg_foreign_data_wrapper",
+    "pg_foreign_server", "pg_foreign_table", "pg_index", "pg_inherits", "pg_language", "pg_largeobject_metadata", "pg_locks",
+    "pg_namespace", "pg_opclass", "pg_operator", "pg_opfamily", "pg_policy", "pg_prepared_statements", "pg_prepared_xacts",
+    "pg_publication", "pg_publication_rel", "pg_rewrite", "pg_roles", "pg_sequence", "pg_settings", "pg_shadow", "pg_shdepend",
+    "pg_shdescription", "pg_stat_gssapi", "pg_subscription", "pg_subscription_rel", "pg_tablespace", "pg_trigger",
+    "pg_ts_config", "pg_ts_dict", "pg_ts_parser", "pg_ts_template", "pg_type", "pg_user",
+    /* `pg_proc` contains `procost` and `prorows` but both seem to be fully static data. */
+    "pg_proc",
+    /**/
+};
+
+static AllowedCols g_pg_catalog_allowed_cols[] = {
+    /* In `pg_class` there is `reltuples` which must be blocked, causing some less annoying breakage in some clients. */
+    {.rel_name = "pg_class", .col_names = {"tableoid", "oid", "relname", "relnamespace", "relowner", "relkind", "reloftype", "relam", "reltablespace", "reltoastrelid", "relhasindex", "relpersistence", "relchecks", "relhasrules", "relhastriggers", "relrowsecurity", "relforcerowsecurity", "relreplident", "relispartition", "relpartbound", "reloptions", "xmin", "reltoastrelid", "relispopulated", "relacl"}},
+    {.rel_name = "pg_statistic_ext", .col_names = {"tableoid", "oid", "stxrelid", "stxname", "stxnamespace", "stxstattarget", "stxkeys", "stxkind"}},
+    {.rel_name = "pg_stat_activity", .col_names = {"datname", "pid", "usename", "application_name", "client_addr", "backend_start", "xact_start", "query_start", "state_change", "wait_event_type", "wait_event", "state", "query", "backend_type", "client_hostname", "client_port", "backend_start", "backend_xid", "backend_xmin"}},
+    /* 
+     * In `pg_stat_database` there are also `tup_*` and `blks_*` columns, but blocking them doesn't break clients
+     * dramatically, so opting to leave them out to err on the safe side.
+     */
+    {.rel_name = "pg_stat_database", .col_names = {
+                                         "datname",
+                                         "xact_commit",
+                                         "xact_rollback",
+                                     }},
+    /**/
+};
+
+static void prepare_pg_catalog_allowed(Oid relation_oid, AllowedCols *allowed_cols)
+{
+  MemoryContext old_context = MemoryContextSwitchTo(TopMemoryContext);
+  for (int i = 0; allowed_cols->col_names[i] != NULL; i++)
+  {
+    int attnum = get_attnum(relation_oid, allowed_cols->col_names[i]) - FirstLowInvalidHeapAttributeNumber;
+    allowed_cols->cols = bms_add_member(allowed_cols->cols, attnum);
+  }
+  MemoryContextSwitchTo(old_context);
+}
 
 /* Pointers to OID cache which is populated at runtime. */
 static const Oid *const g_implicit_range_udfs[] = {
@@ -131,4 +183,40 @@ bool is_substring_builtin(Oid funcoid)
 bool is_implicit_range_builtin_untrusted(Oid funcoid)
 {
   return is_funcname_member_of(funcoid, g_implicit_range_builtins_untrusted, ARRAY_LENGTH(g_implicit_range_builtins_untrusted));
+}
+
+bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selected_cols)
+{
+  char *rel_name = get_rel_name(relation_oid);
+
+  /* First handle `SELECT count(*) FROM pg_catalog.x`. */
+  if (selected_cols == NULL)
+  {
+    pfree(rel_name);
+    return true;
+  }
+
+  /* Then check if the entire relation is allowed. */
+  for (int i = 0; i < ARRAY_LENGTH(g_pg_catalog_allowed_rels); i++)
+  {
+    if (strcmp(g_pg_catalog_allowed_rels[i], rel_name) == 0)
+    {
+      pfree(rel_name);
+      return true;
+    }
+  }
+
+  /* Otherwise specific selected columns must be checked against the allow-list. */
+  bool allowed = false;
+  for (int i = 0; i < ARRAY_LENGTH(g_pg_catalog_allowed_cols); i++)
+  {
+    if (strcmp(g_pg_catalog_allowed_cols[i].rel_name, rel_name) != 0)
+      continue;
+    if (g_pg_catalog_allowed_cols[i].cols == NULL)
+      prepare_pg_catalog_allowed(relation_oid, &g_pg_catalog_allowed_cols[i]);
+    allowed = bms_is_subset(selected_cols, g_pg_catalog_allowed_cols[i].cols);
+    break;
+  }
+  pfree(rel_name);
+  return allowed;
 }

--- a/src/query/allowed_objects.c
+++ b/src/query/allowed_objects.c
@@ -6,7 +6,7 @@
 #include "utils/memutils.h"
 
 #include "pg_diffix/oid_cache.h"
-#include "pg_diffix/query/allowed_functions.h"
+#include "pg_diffix/query/allowed_objects.h"
 #include "pg_diffix/utils.h"
 
 static const char *const g_allowed_casts[] = {

--- a/src/query/allowed_objects.c
+++ b/src/query/allowed_objects.c
@@ -74,11 +74,8 @@ static AllowedCols g_pg_catalog_allowed_cols[] = {
      * In `pg_stat_database` there are also `tup_*` and `blks_*` columns, but blocking them doesn't break clients
      * dramatically, so opting to leave them out to err on the safe side.
      */
-    {.rel_name = "pg_stat_database", .col_names = {
-                                         "datname",
-                                         "xact_commit",
-                                         "xact_rollback",
-                                     }},
+    {.rel_name = "pg_stat_database", .col_names = {"datname", "xact_commit", "xact_rollback"}},
+    {.rel_name = "pg_seclabel", .col_names = {"classoid", "objoid", "objsubid", "label", "provider"}},
     /**/
 };
 

--- a/src/query/anonymization.c
+++ b/src/query/anonymization.c
@@ -15,7 +15,7 @@
 #include "pg_diffix/aggregation/bucket_scan.h"
 #include "pg_diffix/aggregation/common.h"
 #include "pg_diffix/oid_cache.h"
-#include "pg_diffix/query/allowed_functions.h"
+#include "pg_diffix/query/allowed_objects.h"
 #include "pg_diffix/query/anonymization.h"
 #include "pg_diffix/query/relation.h"
 #include "pg_diffix/query/validation.h"

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -16,7 +16,7 @@
 
 #include "pg_diffix/auth.h"
 #include "pg_diffix/oid_cache.h"
-#include "pg_diffix/query/allowed_functions.h"
+#include "pg_diffix/query/allowed_objects.h"
 #include "pg_diffix/query/validation.h"
 #include "pg_diffix/utils.h"
 

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -13,7 +13,6 @@
 #include "utils/builtins.h"
 #include "utils/fmgrprotos.h"
 #include "utils/lsyscache.h"
-#include "utils/memutils.h"
 
 #include "pg_diffix/auth.h"
 #include "pg_diffix/oid_cache.h"
@@ -33,7 +32,6 @@ static void verify_rtable(Query *query);
 static void verify_aggregators(Query *query);
 static void verify_non_system_column(Var *var);
 static bool option_matches(DefElem *option, char *name, bool value);
-static bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selected_cols);
 
 void verify_utility_command(Node *utility_stmt)
 {
@@ -366,89 +364,4 @@ double numeric_value_to_double(Oid type, Datum value)
 static bool option_matches(DefElem *option, char *name, bool value)
 {
   return strcasecmp(option->defname, name) == 0 && defGetBoolean(option) == value;
-}
-
-typedef struct AllowedCols
-{
-  const char *rel_name;             /* Name of the relation */
-  Bitmapset *cols;                  /* Indices of the allowed columns of the relation */
-  const char *const col_names[100]; /* Names of columns in the relation */
-} AllowedCols;
-
-static const char *const g_pg_catalog_allowed_rels[] = {
-    "pg_aggregate", "pg_am", "pg_attrdef", "pg_attribute", "pg_auth_members", "pg_authid", "pg_available_extension_versions",
-    "pg_available_extensions", "pg_cast", "pg_collation", "pg_constraint", "pg_database", "pg_db_role_setting", "pg_default_acl",
-    "pg_depend", "pg_depend", "pg_description", "pg_event_trigger", "pg_extension", "pg_foreign_data_wrapper",
-    "pg_foreign_server", "pg_foreign_table", "pg_index", "pg_inherits", "pg_language", "pg_largeobject_metadata", "pg_locks",
-    "pg_namespace", "pg_opclass", "pg_operator", "pg_opfamily", "pg_policy", "pg_prepared_statements", "pg_prepared_xacts",
-    "pg_publication", "pg_publication_rel", "pg_rewrite", "pg_roles", "pg_sequence", "pg_settings", "pg_shadow", "pg_shdepend",
-    "pg_shdescription", "pg_stat_gssapi", "pg_subscription", "pg_subscription_rel", "pg_tablespace", "pg_trigger",
-    "pg_ts_config", "pg_ts_dict", "pg_ts_parser", "pg_ts_template", "pg_type", "pg_user",
-    /* `pg_proc` contains `procost` and `prorows` but both seem to be fully static data. */
-    "pg_proc",
-    /**/
-};
-
-static AllowedCols g_pg_catalog_allowed_cols[] = {
-    /* In `pg_class` there is `reltuples` which must be blocked, causing some less annoying breakage in some clients. */
-    {.rel_name = "pg_class", .col_names = {"tableoid", "oid", "relname", "relnamespace", "relowner", "relkind", "reloftype", "relam", "reltablespace", "reltoastrelid", "relhasindex", "relpersistence", "relchecks", "relhasrules", "relhastriggers", "relrowsecurity", "relforcerowsecurity", "relreplident", "relispartition", "relpartbound", "reloptions", "xmin", "reltoastrelid", "relispopulated", "relacl"}},
-    {.rel_name = "pg_statistic_ext", .col_names = {"tableoid", "oid", "stxrelid", "stxname", "stxnamespace", "stxstattarget", "stxkeys", "stxkind"}},
-    {.rel_name = "pg_stat_activity", .col_names = {"datname", "pid", "usename", "application_name", "client_addr", "backend_start", "xact_start", "query_start", "state_change", "wait_event_type", "wait_event", "state", "query", "backend_type", "client_hostname", "client_port", "backend_start", "backend_xid", "backend_xmin"}},
-    /* 
-     * In `pg_stat_database` there are also `tup_*` and `blks_*` columns, but blocking them doesn't break clients
-     * dramatically, so opting to leave them out to err on the safe side.
-     */
-    {.rel_name = "pg_stat_database", .col_names = {
-                                         "datname",
-                                         "xact_commit",
-                                         "xact_rollback",
-                                     }},
-    /**/
-};
-
-static void prepare_pg_catalog_allowed(Oid relation_oid, AllowedCols *allowed_cols)
-{
-  MemoryContext old_context = MemoryContextSwitchTo(TopMemoryContext);
-  for (int i = 0; allowed_cols->col_names[i] != NULL; i++)
-  {
-    int attnum = get_attnum(relation_oid, allowed_cols->col_names[i]) - FirstLowInvalidHeapAttributeNumber;
-    allowed_cols->cols = bms_add_member(allowed_cols->cols, attnum);
-  }
-  MemoryContextSwitchTo(old_context);
-}
-
-static bool is_allowed_pg_catalog_rte(Oid relation_oid, const Bitmapset *selected_cols)
-{
-  char *rel_name = get_rel_name(relation_oid);
-
-  /* First handle `SELECT count(*) FROM pg_catalog.x`. */
-  if (selected_cols == NULL)
-  {
-    pfree(rel_name);
-    return true;
-  }
-
-  /* Then check if the entire relation is allowed. */
-  for (int i = 0; i < ARRAY_LENGTH(g_pg_catalog_allowed_rels); i++)
-  {
-    if (strcmp(g_pg_catalog_allowed_rels[i], rel_name) == 0)
-    {
-      pfree(rel_name);
-      return true;
-    }
-  }
-
-  /* Otherwise specific selected columns must be checked against the allow-list. */
-  bool allowed = false;
-  for (int i = 0; i < ARRAY_LENGTH(g_pg_catalog_allowed_cols); i++)
-  {
-    if (strcmp(g_pg_catalog_allowed_cols[i].rel_name, rel_name) != 0)
-      continue;
-    if (g_pg_catalog_allowed_cols[i].cols == NULL)
-      prepare_pg_catalog_allowed(relation_oid, &g_pg_catalog_allowed_cols[i]);
-    allowed = bms_is_subset(selected_cols, g_pg_catalog_allowed_cols[i].cols);
-    break;
-  }
-  pfree(rel_name);
-  return allowed;
 }

--- a/test/expected/validation.out
+++ b/test/expected/validation.out
@@ -239,6 +239,21 @@ Indexes:
 Indexes:
     "empty_test_customers_pkey" PRIMARY KEY, btree (id)
 
+-- Settings and labels UDFs work
+SELECT * FROM diffix.show_settings() LIMIT 2;
+              name              | setting |                                   short_desc                                   
+--------------------------------+---------+--------------------------------------------------------------------------------
+ pg_diffix.compute_suppress_bin | on      | Whether the suppress bin should be computed and included in the query results.
+ pg_diffix.default_access_level | direct  | Access level for unlabeled users.
+(2 rows)
+
+SELECT * FROM diffix.show_labels() LIMIT 2;
+                  object                  |  label   
+------------------------------------------+----------
+ table public.test_customers              | personal
+ column id of table public.test_customers | aid
+(2 rows)
+
 ----------------------------------------------------------------
 -- Unsupported queries
 ----------------------------------------------------------------

--- a/test/sql/validation.sql
+++ b/test/sql/validation.sql
@@ -130,6 +130,10 @@ SELECT (SELECT city FROM test_validation);
 \dt+ empty_test_customers
 \d+ empty_test_customers
 
+-- Settings and labels UDFs work
+SELECT * FROM diffix.show_settings() LIMIT 2;
+SELECT * FROM diffix.show_labels() LIMIT 2;
+
 ----------------------------------------------------------------
 -- Unsupported queries
 ----------------------------------------------------------------


### PR DESCRIPTION
I've got some more unrelated tweaks

1/ I missed that the `jq` was a new addition, so I missed that the main image doesn't work anymore. This should fix it
2/ Something I hinted on earlier - our docs stated that there is a single *-bucket row, while there can be many
3/ A follow up after my recent `pg_catalog` work - this code littering `pg_validation` hurt my eyes, so I moved it to allowed_functions and renamed the file, I think this fits in nicely there.
4/ fix #320 