### PR TITLE
Update default anon params + lift restrictions on top/outlier intervals

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -103,7 +103,7 @@ Default value is `false`.
 #### Low count filter settings
 
 `pg_diffix.low_count_min_threshold` - The lower bound for the number of distinct AID values that must be present in a
-bucket for it to pass the low count filter. Default value is 2.
+bucket for it to pass the low count filter. Default value is 3, must be greater than or equal 2.
 
 `pg_diffix.low_count_mean_gap` - The number of standard deviations between the lower bound and the mean of the
 low count filter threshold. Default value is 2.0.
@@ -126,8 +126,8 @@ Default value is `*`.
 
 `pg_diffix.outlier_count_max` - Default value is 2. Must not be smaller than `outlier_count_min`.
 
-`pg_diffix.top_count_min` - Default value is 4. Must not be greater than `top_count_max`.
+`pg_diffix.top_count_min` - Default value is 3. Must not be greater than `top_count_max`, must be greater than or equal 1.
 
-`pg_diffix.top_count_max` - Default value is 6. Must not be smaller than `top_count_min`.
+`pg_diffix.top_count_max` - Default value is 4. Must not be smaller than `top_count_min`.
 
 **NOTE** The outlier interval `(outlier_count_min, outlier_count_max)` must not be wider than the `(top_count_min, top_count_max)` interval.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -103,7 +103,7 @@ Default value is `false`.
 #### Low count filter settings
 
 `pg_diffix.low_count_min_threshold` - The lower bound for the number of distinct AID values that must be present in a
-bucket for it to pass the low count filter. Default value is 3, must be greater than or equal 2.
+bucket for it to pass the low count filter. Default value is 3, must be greater than or equal to 2.
 
 `pg_diffix.low_count_mean_gap` - The number of standard deviations between the lower bound and the mean of the
 low count filter threshold. Default value is 2.0.
@@ -126,6 +126,6 @@ Default value is `*`.
 
 `pg_diffix.outlier_count_max` - Default value is 2. Must not be smaller than `outlier_count_min`.
 
-`pg_diffix.top_count_min` - Default value is 3. Must not be greater than `top_count_max`, must be greater than or equal 1.
+`pg_diffix.top_count_min` - Default value is 3. Must not be greater than `top_count_max`, must be greater than or equal to 1.
 
 `pg_diffix.top_count_max` - Default value is 4. Must not be smaller than `top_count_min`.

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -129,5 +129,3 @@ Default value is `*`.
 `pg_diffix.top_count_min` - Default value is 3. Must not be greater than `top_count_max`, must be greater than or equal 1.
 
 `pg_diffix.top_count_max` - Default value is 4. Must not be smaller than `top_count_min`.
-
-**NOTE** The outlier interval `(outlier_count_min, outlier_count_max)` must not be wider than the `(top_count_min, top_count_max)` interval.

--- a/src/config.c
+++ b/src/config.c
@@ -183,7 +183,7 @@ void config_init(void)
       "Lower bound of the low count filter threshold.", /* short_desc */
       NULL,                                             /* long_desc */
       &g_config.low_count_min_threshold,                /* valueAddr */
-      2,                                                /* bootValue */
+      3,                                                /* bootValue */
       2,                                                /* minValue */
       MAX_NUMERIC_CONFIG,                               /* maxValue */
       PGC_SUSET,                                        /* context */
@@ -254,7 +254,7 @@ and the mean of the low count filter threshold.", /* short_desc */
       "Minimum top contributors count (inclusive).", /* short_desc */
       "Must not be greater than top_count_max.",     /* long_desc */
       &g_config.top_count_min,                       /* valueAddr */
-      4,                                             /* bootValue */
+      3,                                             /* bootValue */
       1,                                             /* minValue */
       MAX_NUMERIC_CONFIG,                            /* maxValue */
       PGC_SUSET,                                     /* context */
@@ -268,7 +268,7 @@ and the mean of the low count filter threshold.", /* short_desc */
       "Maximum top contributors count (inclusive).", /* short_desc */
       "Must not be smaller than top_count_min.",     /* long_desc */
       &g_config.top_count_max,                       /* valueAddr */
-      6,                                             /* bootValue */
+      4,                                             /* bootValue */
       1,                                             /* minValue */
       MAX_NUMERIC_CONFIG,                            /* maxValue */
       PGC_SUSET,                                     /* context */

--- a/test/expected/_setup.out
+++ b/test/expected/_setup.out
@@ -6,7 +6,8 @@ INSERT INTO test_customers VALUES
   (0, NULL, NULL, NULL), (1, 'Berlin', 1.0, 'Earth'), (2, 'Berlin', 1.0, 'Earth'), (3, 'Rome', 0.5, 'Earth'),
   (4, 'London', 2.0, 'Earth'), (5, 'Berlin', 2.0, 'Earth'), (6, 'Rome', 1.0, 'Earth'), (7, 'Rome', 0.5, 'Earth'),
   (8, 'Berlin', 0.0, 'Earth'), (9, 'Rome', 1.0, 'Earth'), (10, 'Berlin', 2.0, 'Earth'), (11, 'Rome', 1.5, 'Earth'),
-  (12, 'Rome', 0.5, 'Earth'), (13, 'Rome', 0.5, 'Earth'), (14, 'Berlin', 1.5, 'Earth'), (15, 'Berlin', 1.0, 'Earth');
+  (12, 'Rome', 0.5, 'Earth'), (13, 'Rome', 0.5, 'Earth'), (14, 'Berlin', 1.5, 'Earth'), (15, 'Berlin', 1.0, 'Earth'),
+  (16, 'Berlin', 1.0, 'Earth'), (17, 'Madrid', 2.0, 'Earth');
 CREATE TABLE test_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
 INSERT INTO test_products VALUES (0, NULL, NULL), (1, 'Food', 1.5),
   (2, 'Car', 100.0), (3, 'House', 400.0), (4, 'Movie', 10.0);

--- a/test/expected/misc.out
+++ b/test/expected/misc.out
@@ -26,7 +26,7 @@ ON patients.city = customers.city;
   city  | num_customers | num_patients 
 --------+---------------+--------------
  Rome   |             7 |            2
- Berlin |            10 |            2
+ Berlin |             9 |            6
  *      |             2 |             
 (3 rows)
 
@@ -44,7 +44,7 @@ SELECT city, count(*) FROM test_customers GROUP BY city;
 --------+-------
  *      |     2
  Rome   |     7
- Berlin |    10
+ Berlin |     9
 (3 rows)
 
 SELECT count(*), city FROM test_customers GROUP BY city;
@@ -52,7 +52,7 @@ SELECT count(*), city FROM test_customers GROUP BY city;
 -------+--------
      2 | *
      7 | Rome
-    10 | Berlin
+     9 | Berlin
 (3 rows)
 
 -- Same aggregate can be selected multiple times

--- a/test/expected/noiseless.out
+++ b/test/expected/noiseless.out
@@ -22,7 +22,7 @@ SELECT diffix.access_level();
 SELECT COUNT(*) FROM test_customers;
  count 
 -------
-    16
+    18
 (1 row)
 
 SELECT COUNT(*) FROM test_purchases;
@@ -34,7 +34,7 @@ SELECT COUNT(*) FROM test_purchases;
 SELECT COUNT(city), COUNT(DISTINCT city) FROM test_customers;
  count | count 
 -------+-------
-    15 |     2
+    17 |     2
 (1 row)
 
 SELECT COUNT(DISTINCT cid) FROM test_purchases;
@@ -46,9 +46,9 @@ SELECT COUNT(DISTINCT cid) FROM test_purchases;
 SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
   city  | count 
 --------+-------
- *      |     2
+ *      |     3
  Rome   |     7
- Berlin |     7
+ Berlin |     8
 (3 rows)
 
 ----------------------------------------------------------------
@@ -97,6 +97,7 @@ SELECT 1, city FROM test_customers;
 ----------+--------
         1 | *
         1 | *
+        1 | *
         1 | Rome
         1 | Rome
         1 | Rome
@@ -111,13 +112,15 @@ SELECT 1, city FROM test_customers;
         1 | Berlin
         1 | Berlin
         1 | Berlin
-(16 rows)
+        1 | Berlin
+(18 rows)
 
 SELECT city, 'aaaa' FROM test_customers;
   city  | ?column? 
 --------+----------
  *      | aaaa
  *      | aaaa
+ *      | aaaa
  Rome   | aaaa
  Rome   | aaaa
  Rome   | aaaa
@@ -132,7 +135,8 @@ SELECT city, 'aaaa' FROM test_customers;
  Berlin | aaaa
  Berlin | aaaa
  Berlin | aaaa
-(16 rows)
+ Berlin | aaaa
+(18 rows)
 
 ----------------------------------------------------------------
 -- Multi-AID queries
@@ -172,13 +176,16 @@ SELECT id FROM test_customers;
    
    
    
-(16 rows)
+   
+   
+(18 rows)
 
 SELECT city FROM test_customers;
   city  
 --------
  *
  *
+ *
  Rome
  Rome
  Rome
@@ -193,7 +200,8 @@ SELECT city FROM test_customers;
  Berlin
  Berlin
  Berlin
-(16 rows)
+ Berlin
+(18 rows)
 
 SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
   city  
@@ -230,18 +238,17 @@ SELECT COUNT(DISTINCT planet) FROM test_customers;
 SELECT city, COUNT(DISTINCT city) FROM test_customers GROUP BY 1;
   city  | count 
 --------+-------
- *      |     2
- Rome   |     2
- Berlin |     2
+ *      |     3
+ Rome   |     3
+ Berlin |     3
 (3 rows)
 
 SELECT discount, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
  discount | count 
 ----------+-------
-          |     2
-      1.5 |     2
+          |     4
       0.5 |     4
-        1 |     5
-        2 |     2
-(5 rows)
+        1 |     6
+        2 |     4
+(4 rows)
 

--- a/test/expected/noisy.out
+++ b/test/expected/noisy.out
@@ -18,7 +18,7 @@ SELECT diffix.access_level();
 SELECT COUNT(*) FROM test_customers;
  count 
 -------
-    15
+     4
 (1 row)
 
 SELECT COUNT(*) FROM test_purchases;
@@ -30,7 +30,7 @@ SELECT COUNT(*) FROM test_purchases;
 SELECT COUNT(city), COUNT(DISTINCT city) FROM test_customers;
  count | count 
 -------+-------
-    14 |     1
+     4 |     1
 (1 row)
 
 SELECT COUNT(DISTINCT cid) FROM test_purchases;
@@ -40,10 +40,10 @@ SELECT COUNT(DISTINCT cid) FROM test_purchases;
 (1 row)
 
 SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
-  city  | count 
---------+-------
- Rome   |     8
- Berlin |    25
+ city | count 
+------+-------
+ *    |    16
+ Rome |     8
 (2 rows)
 
 ----------------------------------------------------------------
@@ -56,8 +56,7 @@ SELECT 1 FROM test_patients;
         1
         1
         1
-        1
-(5 rows)
+(4 rows)
 
 SELECT cast(1 as real) FROM test_patients;
  float4 
@@ -66,18 +65,33 @@ SELECT cast(1 as real) FROM test_patients;
       1
       1
       1
-      1
-(5 rows)
+(4 rows)
 
 SELECT 1, COUNT(*) FROM test_patients;
  ?column? | count 
 ----------+-------
-        1 |     5
+        1 |     4
 (1 row)
 
 SELECT 1, city FROM test_customers;
- ?column? |  city  
-----------+--------
+ ?column? | city 
+----------+------
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
+        1 | *
         1 | Rome
         1 | Rome
         1 | Rome
@@ -86,70 +100,36 @@ SELECT 1, city FROM test_customers;
         1 | Rome
         1 | Rome
         1 | Rome
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-        1 | Berlin
-(33 rows)
+(24 rows)
 
 SELECT city, 'aaaa' FROM test_customers;
-  city  | ?column? 
---------+----------
- Rome   | aaaa
- Rome   | aaaa
- Rome   | aaaa
- Rome   | aaaa
- Rome   | aaaa
- Rome   | aaaa
- Rome   | aaaa
- Rome   | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
- Berlin | aaaa
-(33 rows)
+ city | ?column? 
+------+----------
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ *    | aaaa
+ Rome | aaaa
+ Rome | aaaa
+ Rome | aaaa
+ Rome | aaaa
+ Rome | aaaa
+ Rome | aaaa
+ Rome | aaaa
+ Rome | aaaa
+(24 rows)
 
 ----------------------------------------------------------------
 -- Multi-AID queries
@@ -163,7 +143,7 @@ SELECT city FROM test_patients GROUP BY 1;
 SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM test_patients;
  count | count | count 
 -------+-------+-------
-     5 |     5 |     0
+     4 |     4 |     0
 (1 row)
 
 ----------------------------------------------------------------
@@ -188,22 +168,27 @@ SELECT id FROM test_customers;
    
    
    
-   
-   
-   
-   
-   
-   
-   
-   
-   
-   
-   
-(27 rows)
+(16 rows)
 
 SELECT city FROM test_customers;
-  city  
---------
+ city 
+------
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
+ *
  Rome
  Rome
  Rome
@@ -212,37 +197,12 @@ SELECT city FROM test_customers;
  Rome
  Rome
  Rome
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
- Berlin
-(33 rows)
+(24 rows)
 
 SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
-  city  
---------
- Berlin
+ city 
+------
+ *
 (1 row)
 
 SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;

--- a/test/sql/_setup.sql
+++ b/test/sql/_setup.sql
@@ -7,7 +7,8 @@ INSERT INTO test_customers VALUES
   (0, NULL, NULL, NULL), (1, 'Berlin', 1.0, 'Earth'), (2, 'Berlin', 1.0, 'Earth'), (3, 'Rome', 0.5, 'Earth'),
   (4, 'London', 2.0, 'Earth'), (5, 'Berlin', 2.0, 'Earth'), (6, 'Rome', 1.0, 'Earth'), (7, 'Rome', 0.5, 'Earth'),
   (8, 'Berlin', 0.0, 'Earth'), (9, 'Rome', 1.0, 'Earth'), (10, 'Berlin', 2.0, 'Earth'), (11, 'Rome', 1.5, 'Earth'),
-  (12, 'Rome', 0.5, 'Earth'), (13, 'Rome', 0.5, 'Earth'), (14, 'Berlin', 1.5, 'Earth'), (15, 'Berlin', 1.0, 'Earth');
+  (12, 'Rome', 0.5, 'Earth'), (13, 'Rome', 0.5, 'Earth'), (14, 'Berlin', 1.5, 'Earth'), (15, 'Berlin', 1.0, 'Earth'),
+  (16, 'Berlin', 1.0, 'Earth'), (17, 'Madrid', 2.0, 'Earth');
 
 CREATE TABLE test_products (id INTEGER PRIMARY KEY, name TEXT, price REAL);
 INSERT INTO test_products VALUES (0, NULL, NULL), (1, 'Food', 1.5),


### PR DESCRIPTION
1. This updates the anon params to match Diffix for Desktop. The changes to the test data are driven by the fact, that if we increase the default `low_threshold`, then the tests seem to cover much less of *-bucket functionality. I opted to retain this coverage and add some protected entities to the test data, that does the trick
2. The other change is https://github.com/diffix/reference/pull/312 translated to `pg_diffix`, it was planned at the time of that PR, slipped my mind and never happened. It is a good opportunity to do so, as now our requirements towards the parameters the user provides should be fully up-to-date