### PR TITLE
Include roles in show_labels function

### DIFF
--- a/pg_diffix--0.0.1.sql
+++ b/pg_diffix--0.0.1.sql
@@ -29,12 +29,11 @@ $$
 SECURITY INVOKER SET search_path = '';
 
 CREATE FUNCTION show_labels()
-RETURNS table(object text, label text)
+RETURNS table(objtype text, objname text, label text)
 LANGUAGE SQL
 AS $$
-  SELECT
-    pg_describe_object(classoid, objoid, objsubid), label
-  FROM pg_seclabel
+  SELECT objtype, objname, label
+  FROM pg_seclabels
   WHERE provider = 'pg_diffix';
 $$
 SECURITY INVOKER SET search_path = '';

--- a/test/expected/validation.out
+++ b/test/expected/validation.out
@@ -247,11 +247,11 @@ SELECT * FROM diffix.show_settings() LIMIT 2;
  pg_diffix.default_access_level | direct  | Access level for unlabeled users.
 (2 rows)
 
-SELECT * FROM diffix.show_labels() LIMIT 2;
-                  object                  |  label   
-------------------------------------------+----------
- table public.test_customers              | personal
- column id of table public.test_customers | aid
+SELECT * FROM diffix.show_labels() WHERE objname LIKE 'public.test_customers%';
+ objtype |         objname          |  label   
+---------+--------------------------+----------
+ table   | public.test_customers    | personal
+ column  | public.test_customers.id | aid
 (2 rows)
 
 ----------------------------------------------------------------

--- a/test/sql/validation.sql
+++ b/test/sql/validation.sql
@@ -132,7 +132,7 @@ SELECT (SELECT city FROM test_validation);
 
 -- Settings and labels UDFs work
 SELECT * FROM diffix.show_settings() LIMIT 2;
-SELECT * FROM diffix.show_labels() LIMIT 2;
+SELECT * FROM diffix.show_labels() WHERE objname LIKE 'public.test_customers%';
 
 ----------------------------------------------------------------
 -- Unsupported queries


### PR DESCRIPTION
Closes #321 by including role labels in `diffix.show_labels()`. Makes the result more ergonomic by using `pg_seclabels` view. 