### PR TITLE
Parity with reference wrt. noisy LCF

### DIFF
--- a/pg_diffix/aggregation/noise.h
+++ b/pg_diffix/aggregation/noise.h
@@ -17,6 +17,6 @@ extern double generate_layered_noise(const seed_t *seeds, int seeds_count,
 /*
  * Returns the noisy LCF threshold for the given noise layers.
  */
-extern int generate_lcf_threshold(const seed_t *seeds, int seeds_count);
+extern double generate_lcf_threshold(const seed_t *seeds, int seeds_count);
 
 #endif /* PG_DIFFIX_NOISE_H */

--- a/src/aggregation/count_distinct.c
+++ b/src/aggregation/count_distinct.c
@@ -88,7 +88,7 @@ static bool aid_set_is_high_count(seed_t bucket_seed, const List *aid_values_set
   seed_t aid_seed = hash_set_to_seed(aid_values_set);
 
   seed_t seeds[] = {bucket_seed, aid_seed};
-  int threshold = generate_lcf_threshold(seeds, ARRAY_LENGTH(seeds));
+  double threshold = generate_lcf_threshold(seeds, ARRAY_LENGTH(seeds));
 
   return list_length(aid_values_set) >= threshold;
 }

--- a/src/aggregation/low_count.c
+++ b/src/aggregation/low_count.c
@@ -10,7 +10,7 @@
 typedef struct AidResult
 {
   seed_t aid_seed;
-  int threshold;
+  double threshold;
   bool low_count;
 } AidResult;
 

--- a/src/aggregation/noise.c
+++ b/src/aggregation/noise.c
@@ -114,8 +114,12 @@ double generate_layered_noise(const seed_t *seeds, int seeds_count,
 
 double generate_lcf_threshold(const seed_t *seeds, int seeds_count)
 {
+  /* 
+   * `low_count_mean_gap` is the number of (total!) standard deviations between
+   * `low_count_min_threshold` and desired mean.
+   */
   double threshold_mean = (double)g_config.low_count_min_threshold +
-                          g_config.low_count_mean_gap * g_config.low_count_layer_sd;
+                          g_config.low_count_mean_gap * g_config.low_count_layer_sd * sqrt(2.0);
   double noise = generate_layered_noise(seeds, seeds_count, "suppress", g_config.low_count_layer_sd);
   double noisy_threshold = threshold_mean + noise;
   return Max(noisy_threshold, g_config.low_count_min_threshold);

--- a/src/aggregation/noise.c
+++ b/src/aggregation/noise.c
@@ -112,11 +112,11 @@ double generate_layered_noise(const seed_t *seeds, int seeds_count,
   return noise;
 }
 
-int generate_lcf_threshold(const seed_t *seeds, int seeds_count)
+double generate_lcf_threshold(const seed_t *seeds, int seeds_count)
 {
   double threshold_mean = (double)g_config.low_count_min_threshold +
                           g_config.low_count_mean_gap * g_config.low_count_layer_sd;
   double noise = generate_layered_noise(seeds, seeds_count, "suppress", g_config.low_count_layer_sd);
-  int noisy_threshold = (int)(threshold_mean + noise);
+  double noisy_threshold = threshold_mean + noise;
   return Max(noisy_threshold, g_config.low_count_min_threshold);
 }

--- a/test/expected/noisy.out
+++ b/test/expected/noisy.out
@@ -1,6 +1,6 @@
 LOAD 'pg_diffix';
 SET pg_diffix.noise_layer_sd = 7;
-SET pg_diffix.low_count_layer_sd = 3;
+SET pg_diffix.low_count_layer_sd = 2;
 SET pg_diffix.low_count_min_threshold = 2;
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'anonymized_trusted';

--- a/test/expected/noisy.out
+++ b/test/expected/noisy.out
@@ -1,6 +1,7 @@
 LOAD 'pg_diffix';
 SET pg_diffix.noise_layer_sd = 7;
 SET pg_diffix.low_count_layer_sd = 3;
+SET pg_diffix.low_count_min_threshold = 2;
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'anonymized_trusted';
 ----------------------------------------------------------------

--- a/test/sql/noisy.sql
+++ b/test/sql/noisy.sql
@@ -1,7 +1,7 @@
 LOAD 'pg_diffix';
 
 SET pg_diffix.noise_layer_sd = 7;
-SET pg_diffix.low_count_layer_sd = 3;
+SET pg_diffix.low_count_layer_sd = 2;
 SET pg_diffix.low_count_min_threshold = 2;
 
 SET ROLE diffix_test;

--- a/test/sql/noisy.sql
+++ b/test/sql/noisy.sql
@@ -2,6 +2,7 @@ LOAD 'pg_diffix';
 
 SET pg_diffix.noise_layer_sd = 7;
 SET pg_diffix.low_count_layer_sd = 3;
+SET pg_diffix.low_count_min_threshold = 2;
 
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'anonymized_trusted';


### PR DESCRIPTION
Closes #345, 

Fixes 2 discrepancies as the commits indicate. Will be accompanied by a PR in `reference` for a third discrepancy and fourth in #346 