### PR TITLE
Parity with reference wrt. noisy counts

### DIFF
--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -138,13 +138,15 @@ CountResult aggregate_count_contributions(
   /* Compensate for the unaccounted for NULL-value AIDs. */
   double flattened_unaccounted_for = Max((double)unacounted_for - result.flattening, 0.0);
 
-  result.flattened_count = result.true_count - result.flattening + flattened_unaccounted_for;
+  result.flattened_count = result.true_count - result.flattening;
 
   double average = result.flattened_count / (double)distinct_contributors;
   double noise_scale = Max(average, 0.5 * top_average);
   result.noise_sd = g_config.noise_layer_sd * noise_scale;
   seed_t noise_layers[] = {bucket_seed, aid_seed};
   result.noise = generate_layered_noise(noise_layers, ARRAY_LENGTH(noise_layers), "noise", result.noise_sd);
+
+  result.flattened_count += flattened_unaccounted_for;
 
   return result;
 }

--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -182,6 +182,12 @@ void accumulate_count_result(CountResultAccumulator *accumulator, const CountRes
     accumulator->max_noise_sd = result->noise_sd;
     accumulator->noise_with_max_sd = result->noise;
   }
+  else if (result->noise_sd == accumulator->max_noise_sd &&
+           fabs(result->noise) > fabs(accumulator->noise_with_max_sd))
+  {
+    /* For determinism, resolve draws using maximum absolute noise value. */
+    accumulator->noise_with_max_sd = result->noise;
+  }
 }
 
 int64 finalize_count_result(const CountResultAccumulator *accumulator)

--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -194,8 +194,7 @@ void accumulate_count_result(CountResultAccumulator *accumulator, const CountRes
 
 int64 finalize_count_result(const CountResultAccumulator *accumulator)
 {
-  int64 rounded_noisy_count = (int64)round(accumulator->count_for_flattening + accumulator->noise_with_max_sd);
-  return Max(rounded_noisy_count, 0);
+  return (int64)round(accumulator->count_for_flattening + accumulator->noise_with_max_sd);
 }
 
 /*-------------------------------------------------------------------------

--- a/src/aggregation/count_distinct.c
+++ b/src/aggregation/count_distinct.c
@@ -317,9 +317,9 @@ static void process_lc_values_contributions(List *per_aid_values,
   foreach (cell, per_aid_values)
   {
     PerAidValuesEntry *entry = (PerAidValuesEntry *)lfirst(cell);
-    *aid_seed ^= entry->aid;
     if (entry->contributions > 0)
     {
+      *aid_seed ^= entry->aid;
       Contributor contributor = {.aid = entry->aid, .contribution = {.integer = entry->contributions}};
       add_top_contributor(&count_descriptor, top_contributors, contributor);
       (*contributors_count)++;

--- a/src/config.c
+++ b/src/config.c
@@ -279,7 +279,7 @@ void config_init(void)
       NULL,                                             /* long_desc */
       &g_config.low_count_min_threshold,                /* valueAddr */
       3,                                                /* bootValue */
-      2,                                                /* minValue */
+      1,                                                /* minValue */
       MAX_NUMERIC_CONFIG,                               /* maxValue */
       PGC_SUSET,                                        /* context */
       0,                                                /* flags */


### PR DESCRIPTION
Continuation of #348, this time we switch on the noise for noisy counts, i.e. `noise_layer_sd`.

This required a bunch of changes to match reference. mostly minor. I always took reference as reference when changing, so if anything looks off, maybe we need to fix `reference` instead.

There's also a slightly unrelated change [Lower the (non strict!) low_count_min_threshold minValue to 1](https://github.com/diffix/pg_diffix/commit/a7d7666ee1362c67f156017ce1287c9f78632061). Since now we have the `strict` flag, which ensures that this setting is at the minimum safe value anyway, it makes sense to allow it to be as low as `1` in case `strict=false`. This, along with zero std. dev., will turn suppression off. This matches current `reference` as well, I just missed it before.

A minor change in `reference` coming up soon...