### PR TITLE
Parity with reference wrt. noisy flattening

### DIFF
--- a/pg_diffix/aggregation/contribution_tracker.h
+++ b/pg_diffix/aggregation/contribution_tracker.h
@@ -46,7 +46,6 @@ typedef struct Contributors
 typedef struct ContributionTrackerHashEntry
 {
   Contributor contributor; /* Contributor info */
-  bool has_contribution;   /* Whether the AID has contributed yet */
   char status;             /* Required for hash table */
 } ContributionTrackerHashEntry;
 
@@ -72,15 +71,6 @@ typedef struct ContributionTrackerState
   /* Variable size field, has to be last in the list. */
   Contributors top_contributors; /* AIDs with largest contributions */
 } ContributionTrackerState;
-
-/*
- * Updates state with an AID without contribution. Requires the caller to provide the appropriate `zero_contribution`
- * for initialization.
- */
-extern void contribution_tracker_update_aid(
-    ContributionTrackerState *state,
-    aid_t aid,
-    contribution_t zero_contribution);
 
 /*
  * Updates state with a contribution from an AID. `contribution` must be greater than zero.

--- a/pg_diffix/aggregation/contribution_tracker.h
+++ b/pg_diffix/aggregation/contribution_tracker.h
@@ -74,12 +74,16 @@ typedef struct ContributionTrackerState
 } ContributionTrackerState;
 
 /*
- * Updates state with an AID without contribution.
+ * Updates state with an AID without contribution. Requires the caller to provide the appropriate `zero_contribution`
+ * for initialization.
  */
-extern void contribution_tracker_update_aid(ContributionTrackerState *state, aid_t aid);
+extern void contribution_tracker_update_aid(
+    ContributionTrackerState *state,
+    aid_t aid,
+    contribution_t zero_contribution);
 
 /*
- * Updates state with a contribution from an AID.
+ * Updates state with a contribution from an AID. `contribution` must be greater than zero.
  */
 extern void contribution_tracker_update_contribution(
     ContributionTrackerState *state,

--- a/pg_diffix/aggregation/count.h
+++ b/pg_diffix/aggregation/count.h
@@ -6,8 +6,6 @@
 
 extern const ContributionDescriptor count_descriptor;
 
-static const contribution_t one_contribution = {.integer = 1};
-
 /* Describes the anonymized count aggregation for one AID instance. */
 typedef struct CountResult
 {

--- a/src/aggregation/contribution_tracker.c
+++ b/src/aggregation/contribution_tracker.c
@@ -156,6 +156,10 @@ void contribution_tracker_update_aid(ContributionTrackerState *state, aid_t aid)
     state->aid_seed ^= aid;
     entry->has_contribution = false;
     state->distinct_contributors++;
+
+    add_top_contributor(&state->contribution_descriptor,
+                        &state->top_contributors,
+                        entry->contributor);
   }
 }
 

--- a/src/aggregation/contribution_tracker.c
+++ b/src/aggregation/contribution_tracker.c
@@ -175,7 +175,8 @@ void contribution_tracker_update_contribution(
                         entry->contributor);
   }
   else
-  { /* Aggregate new contribution. */
+  {
+    /* Aggregate new contribution. */
     entry->contributor.contribution = descriptor->contribution_combine(entry->contributor.contribution, contribution);
     /* We have to check for existence first. If it exists we bump, otherwise we try to insert. */
     update_or_add_top_contributor(

--- a/src/aggregation/contribution_tracker.c
+++ b/src/aggregation/contribution_tracker.c
@@ -152,7 +152,6 @@ ContributionTrackerState *contribution_tracker_new(
   return state;
 }
 
-/* `contribution` must be greater than zero, because of the assumptions of `update_or_add_top_contributor`. */
 void contribution_tracker_update_contribution(
     ContributionTrackerState *state,
     aid_t aid,

--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -10,6 +10,9 @@
 #include "pg_diffix/config.h"
 #include "pg_diffix/query/anonymization.h"
 
+static const contribution_t zero_contribution = {.integer = 0};
+static const contribution_t one_contribution = {.integer = 1};
+
 static bool contribution_greater(contribution_t x, contribution_t y)
 {
   return x.integer > y.integer;
@@ -286,7 +289,7 @@ static void count_merge(AnonAggState *dst_base_state, const AnonAggState *src_ba
         contribution_tracker_update_contribution(
             dst_tracker, entry->contributor.aid, entry->contributor.contribution);
       else
-        contribution_tracker_update_aid(dst_tracker, entry->contributor.aid);
+        contribution_tracker_update_aid(dst_tracker, entry->contributor.aid, zero_contribution);
     }
 
     dst_tracker->unaccounted_for += src_tracker->unaccounted_for;
@@ -316,7 +319,7 @@ static void count_value_transition(AnonAggState *base_state, int num_args, Nulla
       aid_t aid = state->trackers[i]->aid_mapper(args[aid_index].value);
       if (args[COUNT_VALUE_INDEX].isnull)
         /* No contribution since argument is NULL, only keep track of the AID value. */
-        contribution_tracker_update_aid(state->trackers[i], aid);
+        contribution_tracker_update_aid(state->trackers[i], aid, zero_contribution);
       else
         contribution_tracker_update_contribution(state->trackers[i], aid, one_contribution);
     }

--- a/src/aggregation/count.c
+++ b/src/aggregation/count.c
@@ -285,11 +285,7 @@ static void count_merge(AnonAggState *dst_base_state, const AnonAggState *src_ba
     ContributionTrackerHashEntry *entry = NULL;
     while ((entry = ContributionTracker_iterate(src_tracker->contribution_table, &iterator)) != NULL)
     {
-      if (entry->has_contribution)
-        contribution_tracker_update_contribution(
-            dst_tracker, entry->contributor.aid, entry->contributor.contribution);
-      else
-        contribution_tracker_update_aid(dst_tracker, entry->contributor.aid, zero_contribution);
+      contribution_tracker_update_contribution(dst_tracker, entry->contributor.aid, entry->contributor.contribution);
     }
 
     dst_tracker->unaccounted_for += src_tracker->unaccounted_for;
@@ -319,7 +315,7 @@ static void count_value_transition(AnonAggState *base_state, int num_args, Nulla
       aid_t aid = state->trackers[i]->aid_mapper(args[aid_index].value);
       if (args[COUNT_VALUE_INDEX].isnull)
         /* No contribution since argument is NULL, only keep track of the AID value. */
-        contribution_tracker_update_aid(state->trackers[i], aid, zero_contribution);
+        contribution_tracker_update_contribution(state->trackers[i], aid, zero_contribution);
       else
         contribution_tracker_update_contribution(state->trackers[i], aid, one_contribution);
     }


### PR DESCRIPTION
#348 and #351 continued and last of series. With this, fully noisy prop-tests pass.

The first 2 commits is the usual "deterministic / on par" change, the last one is a fix, for a bug which caused the following case to fail on [this assertion](https://github.com/diffix/pg_diffix/blob/master/src/aggregation/contribution_tracker.c#L93), for which I am extremely grateful. Without this, the results could be unpredictably wrong.

```
SET pg_diffix.session_access_level = 'direct'; DELETE FROM pg_seclabel WHERE provider = 'pg_diffix' AND label = 'aid'; SECURITY LABEL FOR pg_diffix ON COLUMN customers.company_name IS 'aid'; SET pg_diffix.salt = 'diffix'; SET pg_diffix.strict = off; SET pg_diffix.noise_layer_sd = 0;SET pg_diffix.low_count_layer_sd = 0.5;SET pg_diffix.low_count_min_threshold = 1;SET pg_diffix.low_count_mean_gap = 1;SET pg_diffix.outlier_count_min = 0;SET pg_diffix.outlier_count_max = 2;SET pg_diffix.top_count_min = 1;SET pg_diffix.top_count_max = 2; SET pg_diffix.session_access_level = 'anonymized_trusted'; \pset pager off

SELECT substring(first_name, 1, 4) as first_name, age, last_name, count(first_name) as count_first_name FROM customers GROUP BY 1, 2, 3 ORDER BY 1 NULLS FIRST, 2 NULLS FIRST, 3 NULLS FIRST;
```

I took the liberty to sprinkle the `contribution_tracker.c` code with some comments in spots which proved a little hard to wrap head around.

A corresponding PR for `reference` to follow :point_down:.