### PR TITLE
Protect against find_agg_funcs(0) on uninitialized oid cache

### DIFF
--- a/src/aggregation/common.c
+++ b/src/aggregation/common.c
@@ -22,9 +22,9 @@ PG_FUNCTION_INFO_V1(anon_agg_state_finalfn);
 
 const AnonAggFuncs *find_agg_funcs(Oid oid)
 {
-  Assert(OidIsValid(oid));
-
-  if (oid == g_oid_cache.anon_count_star)
+  if (!OidIsValid(oid))
+    return NULL;
+  else if (oid == g_oid_cache.anon_count_star)
     return &g_count_star_funcs;
   else if (oid == g_oid_cache.anon_count_value)
     return &g_count_value_funcs;


### PR DESCRIPTION
Just a little fix suggested by Edon, so that in release builds, uninitialized `g_oid_cache` doesn't allow to return `&g_count_star_funcs` for `oid == 0`, which would be nonsense.