### PR TITLE
Add `count_noise` aggregator, unoptimized, unanonymized

### DIFF
--- a/pg_diffix--0.0.1.sql
+++ b/pg_diffix--0.0.1.sql
@@ -159,6 +159,57 @@ AS 'MODULE_PATHNAME'
 LANGUAGE C STABLE
 SECURITY INVOKER SET search_path = '';
 
+
+/* ----------------------------------------------------------------
+ * Non-anonymizing aggregators
+ * ----------------------------------------------------------------
+ */
+
+/*
+ * Present here only to provide the proper signatures for the aggregators available
+ * to the non-direct access users.
+ */
+
+CREATE FUNCTION dummy_transfn(AnonAggState)
+RETURNS AnonAggState
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE
+SECURITY INVOKER SET search_path = '';
+
+CREATE FUNCTION dummy_transfn(AnonAggState, value "any")
+RETURNS AnonAggState
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE
+SECURITY INVOKER SET search_path = '';
+
+CREATE FUNCTION dummy_finalfn(AnonAggState)
+RETURNS AnonAggState
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE
+SECURITY INVOKER SET search_path = '';
+
+CREATE FUNCTION dummy_finalfn(AnonAggState, value "any")
+RETURNS AnonAggState
+AS 'MODULE_PATHNAME'
+LANGUAGE C STABLE
+SECURITY INVOKER SET search_path = '';
+
+CREATE AGGREGATE count_noise(*) (
+  sfunc = dummy_transfn,
+  stype = AnonAggState,
+  finalfunc = dummy_finalfn,
+  finalfunc_extra = true,
+  finalfunc_modify = read_write
+);
+
+CREATE AGGREGATE count_noise(value "any") (
+  sfunc = dummy_transfn,
+  stype = AnonAggState,
+  finalfunc = dummy_finalfn,
+  finalfunc_extra = true,
+  finalfunc_modify = read_write
+);
+
 /* ----------------------------------------------------------------
  * Anonymizing aggregators
  * ----------------------------------------------------------------
@@ -195,6 +246,30 @@ CREATE AGGREGATE anon_count_star(variadic aids "any") (
 );
 
 CREATE AGGREGATE anon_count_value(value "any", variadic aids "any") (
+  sfunc = anon_agg_state_transfn,
+  stype = AnonAggState,
+  finalfunc = anon_agg_state_finalfn,
+  finalfunc_extra = true,
+  finalfunc_modify = read_write
+);
+
+CREATE AGGREGATE anon_count_distinct_noise(value "any", variadic aids "any") (
+  sfunc = anon_agg_state_transfn,
+  stype = AnonAggState,
+  finalfunc = anon_agg_state_finalfn,
+  finalfunc_extra = true,
+  finalfunc_modify = read_write
+);
+
+CREATE AGGREGATE anon_count_star_noise(variadic aids "any") (
+  sfunc = anon_agg_state_transfn,
+  stype = AnonAggState,
+  finalfunc = anon_agg_state_finalfn,
+  finalfunc_extra = true,
+  finalfunc_modify = read_write
+);
+
+CREATE AGGREGATE anon_count_value_noise(value "any", variadic aids "any") (
   sfunc = anon_agg_state_transfn,
   stype = AnonAggState,
   finalfunc = anon_agg_state_finalfn,

--- a/pg_diffix/aggregation/common.h
+++ b/pg_diffix/aggregation/common.h
@@ -96,6 +96,9 @@ typedef struct AnonAggState AnonAggState;
 /* Known anonymizing aggregators. */
 extern const AnonAggFuncs g_count_star_funcs;
 extern const AnonAggFuncs g_count_value_funcs;
+extern const AnonAggFuncs g_count_distinct_noise_funcs;
+extern const AnonAggFuncs g_count_star_noise_funcs;
+extern const AnonAggFuncs g_count_value_noise_funcs;
 extern const AnonAggFuncs g_count_distinct_funcs;
 extern const AnonAggFuncs g_low_count_funcs;
 

--- a/pg_diffix/aggregation/count.h
+++ b/pg_diffix/aggregation/count.h
@@ -35,9 +35,11 @@ typedef struct CountResultAccumulator
   double count_for_flattening;
   double max_noise_sd;
   double noise_with_max_sd;
+  bool not_enough_aid_values;
 } CountResultAccumulator;
 
 extern void accumulate_count_result(CountResultAccumulator *accumulator, const CountResult *result);
 extern int64 finalize_count_result(const CountResultAccumulator *accumulator);
+extern double finalize_count_noise_result(const CountResultAccumulator *accumulator);
 
 #endif /* PG_DIFFIX_COUNT_COMMON_H */

--- a/pg_diffix/oid_cache.h
+++ b/pg_diffix/oid_cache.h
@@ -10,10 +10,16 @@ typedef struct Oids
   Oid count_star;  /* count(*) */
   Oid count_value; /* count(any) */
 
-  Oid low_count;           /* diffix.low_count(aids...) */
-  Oid anon_count_distinct; /* diffix.anon_count_distinct(any, aids...) */
-  Oid anon_count_star;     /* diffix.anon_count_star(aids...) */
-  Oid anon_count_value;    /* diffix.anon_count_value(any, aids...) */
+  Oid count_star_noise;  /* diffix.count_noise(*) */
+  Oid count_value_noise; /* diffix.count_noise(any) */
+
+  Oid low_count;                 /* diffix.low_count(aids...) */
+  Oid anon_count_distinct;       /* diffix.anon_count_distinct(any, aids...) */
+  Oid anon_count_star;           /* diffix.anon_count_star(aids...) */
+  Oid anon_count_value;          /* diffix.anon_count_value(any, aids...) */
+  Oid anon_count_distinct_noise; /* diffix.anon_count_distinct_noise(any, aids...) */
+  Oid anon_count_star_noise;     /* diffix.anon_count_star_noise(aids...) */
+  Oid anon_count_value_noise;    /* diffix.anon_count_value_noise(any, aids...) */
 
   Oid anon_agg_state; /* diffix.AnonAggState */
 

--- a/src/aggregation/common.c
+++ b/src/aggregation/common.c
@@ -19,6 +19,8 @@ PG_FUNCTION_INFO_V1(anon_agg_state_input);
 PG_FUNCTION_INFO_V1(anon_agg_state_output);
 PG_FUNCTION_INFO_V1(anon_agg_state_transfn);
 PG_FUNCTION_INFO_V1(anon_agg_state_finalfn);
+PG_FUNCTION_INFO_V1(dummy_transfn);
+PG_FUNCTION_INFO_V1(dummy_finalfn);
 
 const AnonAggFuncs *find_agg_funcs(Oid oid)
 {
@@ -30,6 +32,12 @@ const AnonAggFuncs *find_agg_funcs(Oid oid)
     return &g_count_value_funcs;
   else if (oid == g_oid_cache.anon_count_distinct)
     return &g_count_distinct_funcs;
+  else if (oid == g_oid_cache.anon_count_star_noise)
+    return &g_count_star_noise_funcs;
+  else if (oid == g_oid_cache.anon_count_value_noise)
+    return &g_count_value_noise_funcs;
+  else if (oid == g_oid_cache.anon_count_distinct_noise)
+    return &g_count_distinct_noise_funcs;
   else if (oid == g_oid_cache.low_count)
     return &g_low_count_funcs;
 
@@ -128,4 +136,20 @@ Datum anon_agg_state_finalfn(PG_FUNCTION_ARGS)
 {
   AnonAggState *state = get_agg_state(fcinfo);
   PG_RETURN_AGG_STATE(state);
+}
+
+/* 
+ * These functions should never be called, non-anonymized `_noise` aggregators are to
+ * be always rewritten to their anonymized versions.
+ */
+Datum dummy_transfn(PG_FUNCTION_ARGS)
+{
+  Assert(false);
+  PG_RETURN_AGG_STATE(0);
+}
+
+Datum dummy_finalfn(PG_FUNCTION_ARGS)
+{
+  Assert(false);
+  PG_RETURN_AGG_STATE(0);
 }

--- a/src/oid_cache.c
+++ b/src/oid_cache.c
@@ -22,10 +22,16 @@ void oid_cache_init(void)
   g_oid_cache.count_star = lookup_function(NULL, "count", 0, (Oid[]){});
   g_oid_cache.count_value = lookup_function(NULL, "count", 1, (Oid[]){ANYOID});
 
+  g_oid_cache.count_star_noise = lookup_function("diffix", "count_noise", 0, (Oid[]){});
+  g_oid_cache.count_value_noise = lookup_function("diffix", "count_noise", 1, (Oid[]){ANYOID});
+
   g_oid_cache.low_count = lookup_function("diffix", "low_count", -1, (Oid[]){});
   g_oid_cache.anon_count_distinct = lookup_function("diffix", "anon_count_distinct", -1, (Oid[]){});
   g_oid_cache.anon_count_star = lookup_function("diffix", "anon_count_star", -1, (Oid[]){});
   g_oid_cache.anon_count_value = lookup_function("diffix", "anon_count_value", -1, (Oid[]){});
+  g_oid_cache.anon_count_distinct_noise = lookup_function("diffix", "anon_count_distinct_noise", -1, (Oid[]){});
+  g_oid_cache.anon_count_star_noise = lookup_function("diffix", "anon_count_star_noise", -1, (Oid[]){});
+  g_oid_cache.anon_count_value_noise = lookup_function("diffix", "anon_count_value_noise", -1, (Oid[]){});
 
   g_oid_cache.anon_agg_state = get_func_rettype(g_oid_cache.anon_count_star);
 
@@ -76,10 +82,16 @@ char *oids_to_string(Oids *oids)
   appendStringInfo(&string, " :count_star %u", oids->count_star);
   appendStringInfo(&string, " :count_value %u", oids->count_value);
 
+  appendStringInfo(&string, " :count_star_noise %u", oids->count_star_noise);
+  appendStringInfo(&string, " :count_value_noise %u", oids->count_value_noise);
+
   appendStringInfo(&string, " :low_count %u", oids->low_count);
   appendStringInfo(&string, " :anon_count_distinct %u", oids->anon_count_distinct);
   appendStringInfo(&string, " :anon_count_star %u", oids->anon_count_star);
   appendStringInfo(&string, " :anon_count_value %u", oids->anon_count_value);
+  appendStringInfo(&string, " :anon_count_distinct_noise %u", oids->anon_count_distinct_noise);
+  appendStringInfo(&string, " :anon_count_star_noise %u", oids->anon_count_star_noise);
+  appendStringInfo(&string, " :anon_count_value_noise %u", oids->anon_count_value_noise);
 
   appendStringInfo(&string, " :anon_agg_state %u", oids->anon_agg_state);
 

--- a/src/query/anonymization.c
+++ b/src/query/anonymization.c
@@ -170,6 +170,12 @@ static Node *aggregate_expression_mutator(Node *node, List *aid_refs)
       rewrite_to_anon_aggregator(aggref, aid_refs, g_oid_cache.anon_count_distinct);
     else if (aggfnoid == g_oid_cache.count_value)
       rewrite_to_anon_aggregator(aggref, aid_refs, g_oid_cache.anon_count_value);
+    else if (aggfnoid == g_oid_cache.count_star_noise)
+      rewrite_to_anon_aggregator(aggref, aid_refs, g_oid_cache.anon_count_star_noise);
+    else if (aggfnoid == g_oid_cache.count_value_noise && aggref->aggdistinct)
+      rewrite_to_anon_aggregator(aggref, aid_refs, g_oid_cache.anon_count_distinct_noise);
+    else if (aggfnoid == g_oid_cache.count_value_noise)
+      rewrite_to_anon_aggregator(aggref, aid_refs, g_oid_cache.anon_count_value_noise);
     /*
     else
       FAILWITH("Unsupported aggregate in query.");

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -176,6 +176,8 @@ static bool verify_aggregator(Node *node, void *context)
 
     if (aggoid != g_oid_cache.count_star &&
         aggoid != g_oid_cache.count_value &&
+        aggoid != g_oid_cache.count_star_noise &&
+        aggoid != g_oid_cache.count_value_noise &&
         aggoid != g_oid_cache.is_suppress_bin)
       FAILWITH_LOCATION(aggref->location, "Unsupported aggregate in query.");
 

--- a/test/expected/noisy.out
+++ b/test/expected/noisy.out
@@ -48,6 +48,15 @@ SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
 (2 rows)
 
 ----------------------------------------------------------------
+-- Reporting noise
+----------------------------------------------------------------
+SELECT diffix.count_noise(*), diffix.count_noise(city), diffix.count_noise(DISTINCT city) FROM test_customers;
+ count_noise |    count_noise    | count_noise 
+-------------+-------------------+-------------
+           7 | 6.611111111111111 |           0
+(1 row)
+
+----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------
 SELECT 1 FROM test_patients;

--- a/test/sql/noisy.sql
+++ b/test/sql/noisy.sql
@@ -27,6 +27,12 @@ SELECT COUNT(DISTINCT cid) FROM test_purchases;
 SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
 
 ----------------------------------------------------------------
+-- Reporting noise
+----------------------------------------------------------------
+
+SELECT diffix.count_noise(*), diffix.count_noise(city), diffix.count_noise(DISTINCT city) FROM test_customers;
+
+----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Closes #367 .

This fills in the "plumbing" for the `count_noise` anonymizing aggregators.

The approach taken slightly mimics the one currently implemented in `reference`:
1. No optimization, i.e. if the query contains `count(*)` and `count_noise(*)` the aggregation and finalization is done twice
2. No anonymization, we're exposing the true noise. The anonymization of reported noise planned should be pretty orthogonal to the "plumbing"
3. The `count_noise` implementation differs from `count` by the "finalizing" functions, which instead of extracting the anonymized sum, extract the noise (in `reference` this is accomplished via inheritance and overriding the Aggregators method).