### PR TITLE
`sum` for numeric and other fixes

### DIFF
--- a/pg_diffix--1.0.0.sql
+++ b/pg_diffix--1.0.0.sql
@@ -170,50 +170,50 @@ SECURITY INVOKER SET search_path = '';
  * to the non-direct access users.
  */
 
-CREATE FUNCTION dummy_transfn(AnonAggState)
+CREATE FUNCTION dummy_agg_noise_transfn(AnonAggState)
 RETURNS AnonAggState
 AS 'MODULE_PATHNAME'
 LANGUAGE C STABLE
 SECURITY INVOKER SET search_path = '';
 
-CREATE FUNCTION dummy_transfn(AnonAggState, value "any")
+CREATE FUNCTION dummy_agg_noise_transfn(AnonAggState, value "any")
 RETURNS AnonAggState
 AS 'MODULE_PATHNAME'
 LANGUAGE C STABLE
 SECURITY INVOKER SET search_path = '';
 
-CREATE FUNCTION dummy_finalfn(AnonAggState)
+CREATE FUNCTION dummy_agg_noise_finalfn(AnonAggState)
 RETURNS float8
 AS 'MODULE_PATHNAME'
 LANGUAGE C STABLE
 SECURITY INVOKER SET search_path = '';
 
-CREATE FUNCTION dummy_finalfn(AnonAggState, value "any")
+CREATE FUNCTION dummy_agg_noise_finalfn(AnonAggState, value "any")
 RETURNS float8
 AS 'MODULE_PATHNAME'
 LANGUAGE C STABLE
 SECURITY INVOKER SET search_path = '';
 
 CREATE AGGREGATE count_noise(*) (
-  sfunc = dummy_transfn,
+  sfunc = dummy_agg_noise_transfn,
   stype = AnonAggState,
-  finalfunc = dummy_finalfn,
+  finalfunc = dummy_agg_noise_finalfn,
   finalfunc_extra = true,
   finalfunc_modify = read_write
 );
 
 CREATE AGGREGATE count_noise(value "any") (
-  sfunc = dummy_transfn,
+  sfunc = dummy_agg_noise_transfn,
   stype = AnonAggState,
-  finalfunc = dummy_finalfn,
+  finalfunc = dummy_agg_noise_finalfn,
   finalfunc_extra = true,
   finalfunc_modify = read_write
 );
 
 CREATE AGGREGATE sum_noise(value "any") (
-  sfunc = dummy_transfn,
+  sfunc = dummy_agg_noise_transfn,
   stype = AnonAggState,
-  finalfunc = dummy_finalfn,
+  finalfunc = dummy_agg_noise_finalfn,
   finalfunc_extra = true,
   finalfunc_modify = read_write
 );

--- a/src/aggregation/common.c
+++ b/src/aggregation/common.c
@@ -19,8 +19,8 @@ PG_FUNCTION_INFO_V1(anon_agg_state_input);
 PG_FUNCTION_INFO_V1(anon_agg_state_output);
 PG_FUNCTION_INFO_V1(anon_agg_state_transfn);
 PG_FUNCTION_INFO_V1(anon_agg_state_finalfn);
-PG_FUNCTION_INFO_V1(dummy_transfn);
-PG_FUNCTION_INFO_V1(dummy_finalfn);
+PG_FUNCTION_INFO_V1(dummy_agg_noise_transfn);
+PG_FUNCTION_INFO_V1(dummy_agg_noise_finalfn);
 
 const AnonAggFuncs *find_agg_funcs(Oid oid)
 {
@@ -143,18 +143,16 @@ Datum anon_agg_state_finalfn(PG_FUNCTION_ARGS)
 }
 
 /* 
- * These functions should never be called, non-anonymized `_noise` aggregators are to
- * be always rewritten to their anonymized versions.
+ * These functions should never be called except in `direct` access level. Non-anonymized `_noise` aggregators are to be
+ * always rewritten to their anonymized versions. In `direct`, they return the true result: 0.0 noise.
  */
-Datum dummy_transfn(PG_FUNCTION_ARGS)
+Datum dummy_agg_noise_transfn(PG_FUNCTION_ARGS)
 {
-  Assert(false);
   PG_RETURN_AGG_STATE(0);
 }
 
-Datum dummy_finalfn(PG_FUNCTION_ARGS)
+Datum dummy_agg_noise_finalfn(PG_FUNCTION_ARGS)
 {
-  Assert(false);
   PG_RETURN_AGG_STATE(0);
 }
 

--- a/src/aggregation/count_distinct.c
+++ b/src/aggregation/count_distinct.c
@@ -339,19 +339,18 @@ typedef struct CountDistinctResult
   int64 lc_values_count;
   int64 noisy_count;
   double noise_sd;
+  bool not_enough_aid_values;
 } CountDistinctResult;
 
 /*
  * The number of high count values is safe to be shown directly, without any extra noise.
  * The number of low count values has to be anonymized.
  */
-static CountDistinctResult count_distinct_calculate_final(AnonAggState *base_state, Bucket *bucket, BucketDescriptor *bucket_desc, bool *is_null)
+static CountDistinctResult count_distinct_calculate_final(AnonAggState *base_state, Bucket *bucket, BucketDescriptor *bucket_desc)
 {
   CountDistinctState *state = (CountDistinctState *)base_state;
 
   seed_t bucket_seed = compute_bucket_seed(bucket, bucket_desc);
-  bool is_global = bucket_desc->num_labels == 0;
-  int64 min_count = is_global ? 0 : g_config.low_count_min_threshold;
 
   int aids_count = state->args_desc->num_args - AIDS_OFFSET;
   set_value_sorting_globals(state->args_desc->args[VALUE_INDEX].type_oid);
@@ -398,16 +397,17 @@ static CountDistinctResult count_distinct_calculate_final(AnonAggState *base_sta
 
     accumulate_result(&result_accumulator, &inner_count_result);
     if (result_accumulator.not_enough_aid_values)
+    {
+      result.not_enough_aid_values = true;
       break;
+    }
   }
 
-  if (!result_accumulator.not_enough_aid_values)
+  if (!result.not_enough_aid_values)
   {
     result.noisy_count += finalize_count_result(&result_accumulator);
     result.noise_sd = finalize_noise_result(&result_accumulator);
   }
-
-  result.noisy_count = Max(result.noisy_count, min_count);
 
   return result;
 }
@@ -451,8 +451,10 @@ static AnonAggState *count_distinct_create_state(MemoryContext memory_context, A
 
 static Datum count_distinct_finalize(AnonAggState *base_state, Bucket *bucket, BucketDescriptor *bucket_desc, bool *is_null)
 {
-  CountDistinctResult result = count_distinct_calculate_final(base_state, bucket, bucket_desc, is_null);
-  return Int64GetDatum(result.noisy_count);
+  bool is_global = bucket_desc->num_labels == 0;
+  int64 min_count = is_global ? 0 : g_config.low_count_min_threshold;
+  CountDistinctResult result = count_distinct_calculate_final(base_state, bucket, bucket_desc);
+  return Int64GetDatum(Max(result.noisy_count, min_count));
 }
 
 static void count_distinct_merge(AnonAggState *dst_base_state, const AnonAggState *src_base_state)
@@ -550,8 +552,16 @@ static void count_distinct_noise_final_type(const ArgsDescriptor *args_desc, Oid
 
 static Datum count_distinct_noise_finalize(AnonAggState *base_state, Bucket *bucket, BucketDescriptor *bucket_desc, bool *is_null)
 {
-  CountDistinctResult result = count_distinct_calculate_final(base_state, bucket, bucket_desc, is_null);
-  return Float8GetDatum(result.noise_sd);
+  CountDistinctResult result = count_distinct_calculate_final(base_state, bucket, bucket_desc);
+  if (result.not_enough_aid_values && result.noisy_count == 0)
+  {
+    *is_null = true;
+    return Float8GetDatum(0.0);
+  }
+  else
+  {
+    return Float8GetDatum(result.noise_sd);
+  }
 }
 
 static const char *count_distinct_noise_explain(const AnonAggState *base_state)

--- a/src/aggregation/sum.c
+++ b/src/aggregation/sum.c
@@ -126,7 +126,6 @@ static Datum sum_finalize(AnonAggState *base_state, Bucket *bucket, BucketDescri
       return Int64GetDatum(0);
     case INT8OID:
     case NUMERICOID:
-      /* Numeric */
       return DirectFunctionCall1(float8_numeric, 0);
     case FLOAT4OID:
       return Float4GetDatum(0);
@@ -146,7 +145,6 @@ static Datum sum_finalize(AnonAggState *base_state, Bucket *bucket, BucketDescri
       return Int64GetDatum((int64)round(finalize_sum_result(&result_accumulator)));
     case INT8OID:
     case NUMERICOID:
-      /* Numeric */
       return DirectFunctionCall1(float8_numeric, Float8GetDatum(finalize_sum_result(&result_accumulator)));
     case FLOAT4OID:
       return Float4GetDatum((float4)finalize_sum_result(&result_accumulator));

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -194,11 +194,8 @@ static bool verify_aggregator(Node *node, void *context)
         FAILWITH_LOCATION(aggref->location, "Unsupported expression as aggregate argument.");
     }
 
-    if (is_sum_oid(aggoid) || aggoid == g_oid_cache.sum_noise)
-    {
-      if (aggref->aggdistinct)
-        FAILWITH_LOCATION(aggref->location, "Unsupported distinct qualifier at aggregate argument.");
-    }
+    if ((is_sum_oid(aggoid) || aggoid == g_oid_cache.sum_noise) && aggref->aggdistinct)
+      FAILWITH_LOCATION(aggref->location, "Unsupported distinct qualifier at aggregate argument.");
 
     NOT_SUPPORTED(aggref->aggfilter, "FILTER clauses in aggregate expressions");
     NOT_SUPPORTED(aggref->aggorder, "ORDER BY clauses in aggregate expressions");

--- a/test/expected/misc.out
+++ b/test/expected/misc.out
@@ -191,3 +191,11 @@ EXPLAIN SELECT city FROM test_customers ORDER BY 1;
                ->  Seq Scan on test_customers
 (6 rows)
 
+-- Tolerate `diffix.agg_noise` in direct access level
+SET pg_diffix.session_access_level = 'direct';
+SELECT diffix.sum_noise(discount), diffix.count_noise(*) FROM test_customers;
+ sum_noise | count_noise 
+-----------+-------------
+         0 |           0
+(1 row)
+

--- a/test/expected/noiseless.out
+++ b/test/expected/noiseless.out
@@ -83,6 +83,17 @@ SELECT city, SUM(discount), diffix.sum_noise(discount) FROM test_customers GROUP
  Berlin |         9 |         0
 (3 rows)
 
+-- sum supports numeric type
+SELECT city, SUM(discount::numeric), pg_typeof(SUM(discount::numeric)), diffix.sum_noise(discount::numeric)
+FROM test_customers
+GROUP BY 1;
+  city  |       sum        | pg_typeof | sum_noise 
+--------+------------------+-----------+-----------
+ *      |                  | numeric   |          
+ Rome   | 4.83333333333333 | numeric   |         0
+ Berlin |                9 | numeric   |         0
+(3 rows)
+
 ----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------

--- a/test/expected/noiseless.out
+++ b/test/expected/noiseless.out
@@ -70,7 +70,7 @@ SELECT SUM(discount), diffix.sum_noise(discount) FROM test_customers;
 SELECT city, SUM(id), diffix.sum_noise(id) FROM test_customers GROUP BY 1;
   city  | sum | sum_noise 
 --------+-----+-----------
- *      |     |         0
+ *      |     |          
  Rome   |  59 |         0
  Berlin |  68 |         0
 (3 rows)
@@ -78,7 +78,7 @@ SELECT city, SUM(id), diffix.sum_noise(id) FROM test_customers GROUP BY 1;
 SELECT city, SUM(discount), diffix.sum_noise(discount) FROM test_customers GROUP BY 1;
   city  |    sum    | sum_noise 
 --------+-----------+-----------
- *      |           |         0
+ *      |           |          
  Rome   | 4.8333335 |         0
  Berlin |         9 |         0
 (3 rows)

--- a/test/sql/misc.sql
+++ b/test/sql/misc.sql
@@ -93,3 +93,7 @@ EXPLAIN (ANALYZE, SUMMARY false, TIMING false, COSTS true) SELECT name FROM test
 
 -- EXPLAIN prints group/sort names
 EXPLAIN SELECT city FROM test_customers ORDER BY 1;
+
+-- Tolerate `diffix.agg_noise` in direct access level
+SET pg_diffix.session_access_level = 'direct';
+SELECT diffix.sum_noise(discount), diffix.count_noise(*) FROM test_customers;

--- a/test/sql/noiseless.sql
+++ b/test/sql/noiseless.sql
@@ -39,6 +39,11 @@ SELECT SUM(discount), diffix.sum_noise(discount) FROM test_customers;
 SELECT city, SUM(id), diffix.sum_noise(id) FROM test_customers GROUP BY 1;
 SELECT city, SUM(discount), diffix.sum_noise(discount) FROM test_customers GROUP BY 1;
 
+-- sum supports numeric type
+SELECT city, SUM(discount::numeric), pg_typeof(SUM(discount::numeric)), diffix.sum_noise(discount::numeric)
+FROM test_customers
+GROUP BY 1;
+
 ----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #370.

After this change the prop-tests don't mind adding in `count_noise`, `sum` and `sum_noise` to the queries.

The result of what happens with `_noise` in the "not enough AIDVs" condition is up for discussion, but this PR at least aligns behavior with `reference`.