### PR TITLE
Add support for simple WHERE clauses.

### DIFF
--- a/pg_diffix/aggregation/common.h
+++ b/pg_diffix/aggregation/common.h
@@ -126,10 +126,11 @@ typedef struct BucketAttribute
 
 typedef struct AnonymizationContext
 {
-  seed_t sql_seed;           /* Static part of bucket seed */
-  AttrNumber *grouping_cols; /* Array of indices into the target list for the grouping columns */
-  int grouping_cols_count;   /* Count of grouping columns */
-  bool expand_buckets;       /* True if buckets have to be expanded for this query */
+  seed_t sql_seed;            /* Static part of bucket seed */
+  List *base_labels_hash_set; /* Hashed labels that apply to all buckets (from filters) */
+  AttrNumber *grouping_cols;  /* Array of indices into the target list for the grouping columns */
+  int grouping_cols_count;    /* Count of grouping columns */
+  bool expand_buckets;        /* True if buckets have to be expanded for this query */
 } AnonymizationContext;
 
 typedef struct BucketDescriptor

--- a/pg_diffix/query/validation.h
+++ b/pg_diffix/query/validation.h
@@ -45,4 +45,14 @@ extern bool is_supported_numeric_type(Oid type);
  */
 extern double numeric_value_to_double(Oid type, Datum value);
 
+/*
+ * Collects matched expressions from an equalities-only filtering clause.
+ */
+extern void collect_equalities_from_filters(Node *node, List **subjects, List **targets);
+
+/*
+ * Returns the first non-cast node.
+ */
+extern Node *unwrap_cast(Node *node);
+
 #endif /* PG_DIFFIX_VALIDATION_H */

--- a/src/query/allowed_objects.c
+++ b/src/query/allowed_objects.c
@@ -10,7 +10,7 @@
 #include "pg_diffix/utils.h"
 
 static const char *const g_allowed_casts[] = {
-    "i2tod", "i2tof", "i2toi4", "i4toi2", "i4tod", "i4tof", "i8tod", "i8tof",
+    "i2tod", "i2tof", "i2toi4", "i4toi2", "i4tod", "i4tof", "i8tod", "i8tof", "int48", "int84",
     "ftod", "dtof",
     "int4_numeric", "float4_numeric", "float8_numeric",
     "numeric_float4", "numeric_float8",

--- a/src/query/anonymization.c
+++ b/src/query/anonymization.c
@@ -427,7 +427,7 @@ static void prepare_bucket_seeds(Query *query, AnonymizationContext *anon_contex
   List *filtering_exprs = NIL, *filtering_consts = NIL;
   collect_equalities_from_filters(query->jointree->quals, &filtering_exprs, &filtering_consts);
 
-  List *seed_material_hash_set = NULL;
+  List *seed_material_hash_set = NIL;
   collect_seed_material_hashes(query, grouping_exprs, &seed_material_hash_set);
   collect_seed_material_hashes(query, filtering_exprs, &seed_material_hash_set);
   anon_context->sql_seed = hash_set_to_seed(seed_material_hash_set);

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -103,11 +103,6 @@ void verify_anonymization_requirements(Query *query)
   verify_rtable(query);
 }
 
-static void verify_where(Query *query)
-{
-  NOT_SUPPORTED(query->jointree->quals, "WHERE clauses in anonymizing queries");
-}
-
 static void verify_rtable(Query *query)
 {
   NOT_SUPPORTED(list_length(query->rtable) > 1, "JOINs in anonymizing queries");
@@ -132,7 +127,7 @@ static bool is_datetime_to_string_cast(CoerceViaIO *expr)
   return TypeCategory(exprType(arg)) == TYPCATEGORY_DATETIME && TypeCategory(expr->resulttype) == TYPCATEGORY_STRING;
 }
 
-static Node *unwrap_cast(Node *node)
+Node *unwrap_cast(Node *node)
 {
   if (IsA(node, FuncExpr))
   {
@@ -255,7 +250,7 @@ static void verify_bucket_expression(Node *node)
   }
   else
   {
-    FAILWITH("Unsupported or unrecognized query node type");
+    FAILWITH("Unsupported bucket expression.");
   }
 }
 
@@ -266,7 +261,7 @@ static void verify_substring(FuncExpr *func_expr)
   Const *second_arg = (Const *)node;
 
   if (DatumGetUInt32(second_arg->constvalue) != 1)
-    FAILWITH_LOCATION(second_arg->location, "Generalization used in the query is not allowed in untrusted access level.");
+    FAILWITH_LOCATION(second_arg->location, "Used bucket expression is not allowed in untrusted access level.");
 }
 
 /* money-style numbers, i.e. 1, 2, or 5 preceeded by or followed by zeros: ⟨... 0.1, 0.2, 0.5, 1, 2, 5, 10, ...⟩ */
@@ -290,13 +285,13 @@ static void verify_bin_size(Node *range_expr)
   Const *range_const = (Const *)range_node;
 
   if (!is_supported_numeric_type(range_const->consttype))
-    FAILWITH_LOCATION(range_const->location, "Unsupported constant type used in generalization.");
+    FAILWITH_LOCATION(range_const->location, "Unsupported constant type used in bucket expression.");
 
   if (!is_money_style(numeric_value_to_double(range_const->consttype, range_const->constvalue)))
-    FAILWITH_LOCATION(range_const->location, "Generalization used in the query is not allowed in untrusted access level.");
+    FAILWITH_LOCATION(range_const->location, "Used bucket expression is not allowed in untrusted access level.");
 }
 
-static void verify_generalization(Node *node)
+static void verify_untrusted_bucket_expression(Node *node)
 {
   if (IsA(node, FuncExpr))
   {
@@ -309,7 +304,7 @@ static void verify_generalization(Node *node)
     else if (is_implicit_range_builtin_untrusted(func_expr->funcid))
       ;
     else
-      FAILWITH_LOCATION(func_expr->location, "Generalization used in the query is not allowed in untrusted access level.");
+      FAILWITH_LOCATION(func_expr->location, "Used bucket expression is not allowed in untrusted access level.");
   }
 }
 
@@ -330,7 +325,7 @@ void verify_bucket_expressions(Query *query)
     Node *expr = (Node *)lfirst(cell);
     verify_bucket_expression(expr);
     if (access_level == ACCESS_ANONYMIZED_UNTRUSTED)
-      verify_generalization(expr);
+      verify_untrusted_bucket_expression(expr);
   }
 }
 
@@ -364,4 +359,63 @@ double numeric_value_to_double(Oid type, Datum value)
 static bool option_matches(DefElem *option, char *name, bool value)
 {
   return strcasecmp(option->defname, name) == 0 && defGetBoolean(option) == value;
+}
+
+static bool is_equality_op(Oid opno)
+{
+  char *opname = get_opname(opno);
+  if (opname == NULL)
+    return false;
+  bool result = strcmp(opname, "=") == 0;
+  pfree(opname);
+  return result;
+}
+
+void collect_equalities_from_filters(Node *node, List **subjects, List **targets)
+{
+  if (node == NULL)
+    return;
+
+  if (is_andclause(node))
+  {
+    ListCell *cell = NULL;
+    foreach (cell, ((BoolExpr *)node)->args)
+      collect_equalities_from_filters(lfirst(cell), subjects, targets);
+    return;
+  }
+
+  if (is_opclause(node))
+  {
+    OpExpr *op_expr = (OpExpr *)node;
+    if (is_equality_op(op_expr->opno))
+    {
+      Assert(list_length(op_expr->args) == 2);
+      *subjects = lappend(*subjects, linitial(op_expr->args));
+      *targets = lappend(*targets, lsecond(op_expr->args));
+      return;
+    }
+  }
+
+  FAILWITH("Only equalities between bucket expressions and constants are allowed as pre-anonymization filters.");
+}
+
+static void verify_where(Query *query)
+{
+  if (get_session_access_level() == ACCESS_ANONYMIZED_UNTRUSTED)
+    NOT_SUPPORTED(query->jointree->quals, "pre-anonymization filters in untrusted mode");
+
+  List *subjects = NIL, *targets = NIL;
+  collect_equalities_from_filters(query->jointree->quals, &subjects, &targets);
+
+  ListCell *subject_cell = NULL, *target_cell = NULL;
+  forboth(subject_cell, subjects, target_cell, targets)
+  {
+    verify_bucket_expression(lfirst(subject_cell));
+
+    if (!IsA(unwrap_cast(lfirst(target_cell)), Const))
+      FAILWITH("Bucket expressions can only be matched against constants in pre-anonymization filters.");
+  }
+
+  list_free(subjects);
+  list_free(targets);
 }

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -208,28 +208,28 @@ static void verify_bucket_expression(Node *node)
     }
 
     if (!is_allowed_function(func_expr->funcid))
-      FAILWITH_LOCATION(func_expr->location, "Unsupported function used to define buckets.");
+      FAILWITH_LOCATION(func_expr->location, "Unsupported function used for generalization.");
 
     Assert(list_length(func_expr->args) > 0); /* All allowed functions require at least one argument. */
 
     if (!IsA(unwrap_cast(linitial(func_expr->args)), Var))
-      FAILWITH_LOCATION(func_expr->location, "Primary argument for a bucket function has to be a simple column reference.");
+      FAILWITH_LOCATION(func_expr->location, "Primary argument for a generalization function has to be a simple column reference.");
 
     for (int i = 1; i < list_length(func_expr->args); i++)
     {
       if (!IsA(unwrap_cast((Node *)list_nth(func_expr->args, i)), Const))
-        FAILWITH_LOCATION(func_expr->location, "Non-primary arguments for a bucket function have to be simple constants.");
+        FAILWITH_LOCATION(func_expr->location, "Non-primary arguments for a generalization function have to be simple constants.");
     }
   }
   else if (IsA(node, OpExpr))
   {
     OpExpr *op_expr = (OpExpr *)node;
-    FAILWITH_LOCATION(op_expr->location, "Use of operators to define buckets is not supported.");
+    FAILWITH_LOCATION(op_expr->location, "Use of operators for generalization is not supported.");
   }
   else if (IsA(node, Const))
   {
     Const *const_expr = (Const *)node;
-    FAILWITH_LOCATION(const_expr->location, "Simple constants are not allowed as bucket expressions.");
+    FAILWITH_LOCATION(const_expr->location, "Simple constants are not allowed as generalization expressions.");
   }
   else if (IsA(node, RelabelType))
   {
@@ -250,7 +250,7 @@ static void verify_bucket_expression(Node *node)
   }
   else
   {
-    FAILWITH("Unsupported bucket expression.");
+    FAILWITH("Unsupported generalization expression.");
   }
 }
 
@@ -261,7 +261,7 @@ static void verify_substring(FuncExpr *func_expr)
   Const *second_arg = (Const *)node;
 
   if (DatumGetUInt32(second_arg->constvalue) != 1)
-    FAILWITH_LOCATION(second_arg->location, "Used bucket expression is not allowed in untrusted access level.");
+    FAILWITH_LOCATION(second_arg->location, "Used generalization expression is not allowed in untrusted access level.");
 }
 
 /* money-style numbers, i.e. 1, 2, or 5 preceeded by or followed by zeros: ⟨... 0.1, 0.2, 0.5, 1, 2, 5, 10, ...⟩ */
@@ -285,10 +285,10 @@ static void verify_bin_size(Node *range_expr)
   Const *range_const = (Const *)range_node;
 
   if (!is_supported_numeric_type(range_const->consttype))
-    FAILWITH_LOCATION(range_const->location, "Unsupported constant type used in bucket expression.");
+    FAILWITH_LOCATION(range_const->location, "Unsupported constant type used in generalization expression.");
 
   if (!is_money_style(numeric_value_to_double(range_const->consttype, range_const->constvalue)))
-    FAILWITH_LOCATION(range_const->location, "Used bucket expression is not allowed in untrusted access level.");
+    FAILWITH_LOCATION(range_const->location, "Used generalization expression is not allowed in untrusted access level.");
 }
 
 static void verify_untrusted_bucket_expression(Node *node)
@@ -304,7 +304,7 @@ static void verify_untrusted_bucket_expression(Node *node)
     else if (is_implicit_range_builtin_untrusted(func_expr->funcid))
       ;
     else
-      FAILWITH_LOCATION(func_expr->location, "Used bucket expression is not allowed in untrusted access level.");
+      FAILWITH_LOCATION(func_expr->location, "Used generalization expression is not allowed in untrusted access level.");
   }
 }
 
@@ -396,7 +396,7 @@ void collect_equalities_from_filters(Node *node, List **subjects, List **targets
     }
   }
 
-  FAILWITH("Only equalities between bucket expressions and constants are allowed as pre-anonymization filters.");
+  FAILWITH("Only equalities between generalization expressions and constants are allowed as pre-anonymization filters.");
 }
 
 static void verify_where(Query *query)
@@ -413,7 +413,7 @@ static void verify_where(Query *query)
     verify_bucket_expression(lfirst(subject_cell));
 
     if (!IsA(unwrap_cast(lfirst(target_cell)), Const))
-      FAILWITH("Bucket expressions can only be matched against constants in pre-anonymization filters.");
+      FAILWITH("Generalization expressions can only be matched against constants in pre-anonymization filters.");
   }
 
   list_free(subjects);

--- a/test/expected/_setup.out
+++ b/test/expected/_setup.out
@@ -26,14 +26,11 @@ INSERT INTO test_patients VALUES
   (5, 'John', 'Berlin', 57), (6, 'Bob', 'Berlin', 19), (7, 'Alice', 'Rome', 37), (8, 'Dan', 'Rome', 37), (9, 'Anna', 'Rome', 64),
   (10, 'Mike', 'London', 64), (11, 'Mike', 'London', 57), (12, 'Mike', 'London', 16), (13, 'Mike', 'London', 17);
 CREATE TABLE empty_test_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT, discount REAL);
--- Pre-filtered table to maintain LCF tests which relied on WHERE clause.
-CREATE TABLE london_customers AS (SELECT * FROM test_customers WHERE city = 'London');
 -- Config tables (and also check handling of namespaces).
 CALL diffix.mark_personal('public.test_customers', 'id');
 CALL diffix.mark_personal('public.test_purchases', 'cid');
 CALL diffix.mark_personal('public.test_patients', 'id', 'name');
 CALL diffix.mark_personal('public.empty_test_customers', 'id');
-CALL diffix.mark_personal('public.london_customers', 'id');
 CALL diffix.mark_public('public.test_products');
 -- There is no CREATE USER IF NOT EXISTS, we need to wrap and silence the output
 DO $$

--- a/test/expected/noiseless.out
+++ b/test/expected/noiseless.out
@@ -52,6 +52,12 @@ SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
  Berlin |     8
 (3 rows)
 
+SELECT COUNT(*) FROM test_customers WHERE planet = 'Earth';
+ count 
+-------
+    17
+(1 row)
+
 ----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------
@@ -211,7 +217,7 @@ SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
  Berlin
 (2 rows)
 
-SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;
+SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM test_customers WHERE city = 'London';
  count | count | count 
 -------+-------+-------
      0 |     0 |     0

--- a/test/expected/noisy.out
+++ b/test/expected/noisy.out
@@ -47,6 +47,12 @@ SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
  Rome |     8
 (2 rows)
 
+SELECT COUNT(*) FROM test_customers WHERE planet = 'Earth';
+ count 
+-------
+    17
+(1 row)
+
 ----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------
@@ -206,7 +212,7 @@ SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
  *
 (1 row)
 
-SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;
+SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM test_customers WHERE city = 'London';
  count | count | count 
 -------+-------+-------
      0 |     0 |     0
@@ -232,5 +238,34 @@ SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM empty_test_customers;
  count | count | count 
 -------+-------+-------
      0 |     0 |     0
+(1 row)
+
+----------------------------------------------------------------
+-- WHERE clauses
+----------------------------------------------------------------
+-- Filtering and grouping produce identical results
+(SELECT count(*) FROM test_customers GROUP BY city HAVING city = 'Berlin')
+UNION
+(SELECT count(*) FROM test_customers WHERE city = 'Berlin');
+ count 
+-------
+    17
+(1 row)
+
+(SELECT count(*) FROM test_customers GROUP BY city, diffix.round_by(discount, 2)
+  HAVING city = 'Berlin' AND diffix.round_by(discount, 2) = 0)
+UNION
+(SELECT count(*) FROM test_customers WHERE city = 'Berlin' AND diffix.round_by(discount, 2) = 0);
+ count 
+-------
+     7
+(1 row)
+
+(SELECT count(*) FROM test_customers WHERE diffix.round_by(discount, 2) = 0 GROUP BY city HAVING city = 'Berlin')
+UNION
+(SELECT count(*) FROM test_customers WHERE city = 'Berlin' AND diffix.round_by(discount, 2) = 0);
+ count 
+-------
+     7
 (1 row)
 

--- a/test/expected/validation.out
+++ b/test/expected/validation.out
@@ -328,46 +328,46 @@ LINE 1: SELECT count(least(id, 5)) FROM test_validation;
                ^
 -- Get rejected because only a subset of expressions is supported for defining buckets.
 SELECT COUNT(*) FROM test_validation GROUP BY LENGTH(city);
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY LENGTH(city);
                                                       ^
 SELECT COUNT(*) FROM test_validation GROUP BY city || 'xxx';
-ERROR:  [PG_DIFFIX] Use of operators to define buckets is not supported.
+ERROR:  [PG_DIFFIX] Use of operators for generalization is not supported.
 LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY city || 'xxx';
                                                            ^
 SELECT LENGTH(city) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT LENGTH(city) FROM test_validation;
                ^
 SELECT city, 'aaaa' FROM test_validation GROUP BY 1, 2;
-ERROR:  [PG_DIFFIX] Simple constants are not allowed as bucket expressions.
+ERROR:  [PG_DIFFIX] Simple constants are not allowed as generalization expressions.
 LINE 1: SELECT city, 'aaaa' FROM test_validation GROUP BY 1, 2;
                      ^
 SELECT COUNT(*) FROM test_validation GROUP BY round(floor(id));
-ERROR:  [PG_DIFFIX] Primary argument for a bucket function has to be a simple column reference.
+ERROR:  [PG_DIFFIX] Primary argument for a generalization function has to be a simple column reference.
 LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY round(floor(id...
                                                       ^
 SELECT COUNT(*) FROM test_validation GROUP BY floor(cast(discount AS integer));
-ERROR:  [PG_DIFFIX] Primary argument for a bucket function has to be a simple column reference.
+ERROR:  [PG_DIFFIX] Primary argument for a generalization function has to be a simple column reference.
 LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY floor(cast(dis...
                                                       ^
 SELECT COUNT(*) FROM test_validation GROUP BY substr(city, 1, id);
-ERROR:  [PG_DIFFIX] Non-primary arguments for a bucket function have to be simple constants.
+ERROR:  [PG_DIFFIX] Non-primary arguments for a generalization function have to be simple constants.
 LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY substr(city, 1...
                                                       ^
 SELECT COUNT(*) FROM test_validation GROUP BY substr('aaaa', 1, 2);
-ERROR:  [PG_DIFFIX] Primary argument for a bucket function has to be a simple column reference.
+ERROR:  [PG_DIFFIX] Primary argument for a generalization function has to be a simple column reference.
 LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY substr('aaaa',...
                                                       ^
 -- Get rejected because expression node type is unsupported.
 SELECT COALESCE(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported bucket expression.
+ERROR:  [PG_DIFFIX] Unsupported generalization expression.
 SELECT NULLIF(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported bucket expression.
+ERROR:  [PG_DIFFIX] Unsupported generalization expression.
 SELECT GREATEST(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported bucket expression.
+ERROR:  [PG_DIFFIX] Unsupported generalization expression.
 SELECT LEAST(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported bucket expression.
+ERROR:  [PG_DIFFIX] Unsupported generalization expression.
 -- Get rejected because of JOINs
 SELECT COUNT(*), COUNT(DISTINCT id), COUNT(DISTINCT cid) FROM test_validation
   INNER JOIN test_purchases tp ON id = cid;
@@ -384,9 +384,9 @@ SELECT city, COUNT(price) FROM test_products CROSS JOIN test_validation GROUP BY
 ERROR:  [PG_DIFFIX] Feature 'JOINs in anonymizing queries' is not currently supported.
 -- Get rejected because of invalid WHERE clauses
 SELECT COUNT(*) FROM test_validation WHERE city <> 'London';
-ERROR:  [PG_DIFFIX] Only equalities between bucket expressions and constants are allowed as pre-anonymization filters.
+ERROR:  [PG_DIFFIX] Only equalities between generalization expressions and constants are allowed as pre-anonymization filters.
 SELECT COUNT(*) FROM test_validation WHERE city = 'London' OR discount = 10;
-ERROR:  [PG_DIFFIX] Only equalities between bucket expressions and constants are allowed as pre-anonymization filters.
+ERROR:  [PG_DIFFIX] Only equalities between generalization expressions and constants are allowed as pre-anonymization filters.
 -- Get rejected because of non-datetime cast to text
 SELECT cast(id AS text) FROM test_validation GROUP BY 1;
 ERROR:  [PG_DIFFIX] Unsupported cast destination type name.
@@ -397,40 +397,40 @@ ERROR:  [PG_DIFFIX] Unsupported cast destination type name.
 LINE 1: SELECT cast(id AS varchar) FROM test_validation GROUP BY 1;
                ^
 SELECT substring(cast(id AS text), 1, 1) FROM test_validation GROUP BY 1;
-ERROR:  [PG_DIFFIX] Primary argument for a bucket function has to be a simple column reference.
+ERROR:  [PG_DIFFIX] Primary argument for a generalization function has to be a simple column reference.
 LINE 1: SELECT substring(cast(id AS text), 1, 1) FROM test_validatio...
                ^
 SELECT substring(cast(id AS varchar), 1, 1) FROM test_validation GROUP BY 1;
-ERROR:  [PG_DIFFIX] Primary argument for a bucket function has to be a simple column reference.
+ERROR:  [PG_DIFFIX] Primary argument for a generalization function has to be a simple column reference.
 LINE 1: SELECT substring(cast(id AS varchar), 1, 1) FROM test_valida...
                ^
 -- Invalid subqueries are rejected.
 SELECT * FROM (SELECT length(city) FROM test_validation) x;
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT * FROM (SELECT length(city) FROM test_validation) x;
                               ^
 SELECT EXISTS (SELECT length(city) FROM test_validation);
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT EXISTS (SELECT length(city) FROM test_validation);
                               ^
 SELECT 1 WHERE EXISTS (SELECT length(city) FROM test_validation);
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT 1 WHERE EXISTS (SELECT length(city) FROM test_validat...
                                       ^
 SELECT 1 UNION SELECT length(city) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT 1 UNION SELECT length(city) FROM test_validation;
                               ^
 SELECT * FROM (SELECT 1) t1, (SELECT length(city) FROM test_validation) t2;
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT * FROM (SELECT 1) t1, (SELECT length(city) FROM test_...
                                              ^
 WITH c AS (SELECT length(city) FROM test_validation) SELECT * FROM c;
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: WITH c AS (SELECT length(city) FROM test_validation) SELECT ...
                           ^
 SELECT (SELECT length(city) FROM test_validation);
-ERROR:  [PG_DIFFIX] Unsupported function used to define buckets.
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
 LINE 1: SELECT (SELECT length(city) FROM test_validation);
                        ^
 -- Get rejected because of accessing pg_catalog tables with sensitive stats
@@ -542,32 +542,32 @@ SELECT diffix.floor_by(discount, 50.0) from test_validation;
 
 -- Get rejected because of invalid generalization parameters
 SELECT substring(city, 2, 2) from test_validation;
-ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used generalization expression is not allowed in untrusted access level.
 LINE 1: SELECT substring(city, 2, 2) from test_validation;
                                ^
 SELECT diffix.floor_by(discount, 3) from test_validation;
-ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used generalization expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.floor_by(discount, 3) from test_validation;
                                          ^
 SELECT diffix.floor_by(discount, 3.0) from test_validation;
-ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used generalization expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.floor_by(discount, 3.0) from test_validation;
                                          ^
 SELECT diffix.floor_by(discount, 5000000000.1) from test_validation;
-ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used generalization expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.floor_by(discount, 5000000000.1) from test_val...
                                          ^
 -- Get rejected because of invalid generalizing functions
 SELECT width_bucket(discount, 2, 200, 5) from test_validation;
-ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used generalization expression is not allowed in untrusted access level.
 LINE 1: SELECT width_bucket(discount, 2, 200, 5) from test_validatio...
                ^
 SELECT ceil(discount) from test_validation;
-ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used generalization expression is not allowed in untrusted access level.
 LINE 1: SELECT ceil(discount) from test_validation;
                ^
 SELECT diffix.ceil_by(discount, 2) from test_validation;
-ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used generalization expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.ceil_by(discount, 2) from test_validation;
                ^
 -- Get rejected because of unsupported features

--- a/test/expected/validation.out
+++ b/test/expected/validation.out
@@ -121,6 +121,19 @@ SELECT city, count(*), diffix.is_suppress_bin(*) from test_validation GROUP BY 1
 ------+-------+-----------------
 (0 rows)
 
+-- Allow simple equality filters in WHERE clauses
+SELECT COUNT(*) FROM test_validation WHERE city = 'London';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM test_validation WHERE substring(city, 1, 1) = 'L' AND discount = 10.0 AND discount = 20.0;
+ count 
+-------
+     0
+(1 row)
+
 -- Set operations between anonymizing queries.
 SELECT city FROM test_validation EXCEPT SELECT city FROM test_validation;
  city 
@@ -348,13 +361,13 @@ LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY substr('aaaa',...
                                                       ^
 -- Get rejected because expression node type is unsupported.
 SELECT COALESCE(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported or unrecognized query node type
+ERROR:  [PG_DIFFIX] Unsupported bucket expression.
 SELECT NULLIF(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported or unrecognized query node type
+ERROR:  [PG_DIFFIX] Unsupported bucket expression.
 SELECT GREATEST(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported or unrecognized query node type
+ERROR:  [PG_DIFFIX] Unsupported bucket expression.
 SELECT LEAST(discount, 20) FROM test_validation;
-ERROR:  [PG_DIFFIX] Unsupported or unrecognized query node type
+ERROR:  [PG_DIFFIX] Unsupported bucket expression.
 -- Get rejected because of JOINs
 SELECT COUNT(*), COUNT(DISTINCT id), COUNT(DISTINCT cid) FROM test_validation
   INNER JOIN test_purchases tp ON id = cid;
@@ -369,9 +382,11 @@ SELECT city, COUNT(price) FROM test_products, test_validation GROUP BY 1;
 ERROR:  [PG_DIFFIX] Feature 'JOINs in anonymizing queries' is not currently supported.
 SELECT city, COUNT(price) FROM test_products CROSS JOIN test_validation GROUP BY 1;
 ERROR:  [PG_DIFFIX] Feature 'JOINs in anonymizing queries' is not currently supported.
--- Get rejected because of WHERE
-SELECT COUNT(*) FROM test_validation WHERE city = 'London';
-ERROR:  [PG_DIFFIX] Feature 'WHERE clauses in anonymizing queries' is not currently supported.
+-- Get rejected because of invalid WHERE clauses
+SELECT COUNT(*) FROM test_validation WHERE city <> 'London';
+ERROR:  [PG_DIFFIX] Only equalities between bucket expressions and constants are allowed as pre-anonymization filters.
+SELECT COUNT(*) FROM test_validation WHERE city = 'London' OR discount = 10;
+ERROR:  [PG_DIFFIX] Only equalities between bucket expressions and constants are allowed as pre-anonymization filters.
 -- Get rejected because of non-datetime cast to text
 SELECT cast(id AS text) FROM test_validation GROUP BY 1;
 ERROR:  [PG_DIFFIX] Unsupported cast destination type name.
@@ -527,31 +542,34 @@ SELECT diffix.floor_by(discount, 50.0) from test_validation;
 
 -- Get rejected because of invalid generalization parameters
 SELECT substring(city, 2, 2) from test_validation;
-ERROR:  [PG_DIFFIX] Generalization used in the query is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
 LINE 1: SELECT substring(city, 2, 2) from test_validation;
                                ^
 SELECT diffix.floor_by(discount, 3) from test_validation;
-ERROR:  [PG_DIFFIX] Generalization used in the query is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.floor_by(discount, 3) from test_validation;
                                          ^
 SELECT diffix.floor_by(discount, 3.0) from test_validation;
-ERROR:  [PG_DIFFIX] Generalization used in the query is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.floor_by(discount, 3.0) from test_validation;
                                          ^
 SELECT diffix.floor_by(discount, 5000000000.1) from test_validation;
-ERROR:  [PG_DIFFIX] Generalization used in the query is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.floor_by(discount, 5000000000.1) from test_val...
                                          ^
 -- Get rejected because of invalid generalizing functions
 SELECT width_bucket(discount, 2, 200, 5) from test_validation;
-ERROR:  [PG_DIFFIX] Generalization used in the query is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
 LINE 1: SELECT width_bucket(discount, 2, 200, 5) from test_validatio...
                ^
 SELECT ceil(discount) from test_validation;
-ERROR:  [PG_DIFFIX] Generalization used in the query is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
 LINE 1: SELECT ceil(discount) from test_validation;
                ^
 SELECT diffix.ceil_by(discount, 2) from test_validation;
-ERROR:  [PG_DIFFIX] Generalization used in the query is not allowed in untrusted access level.
+ERROR:  [PG_DIFFIX] Used bucket expression is not allowed in untrusted access level.
 LINE 1: SELECT diffix.ceil_by(discount, 2) from test_validation;
                ^
+-- Get rejected because of unsupported features
+SELECT count(*) FROM test_validation WHERE discount = 3;
+ERROR:  [PG_DIFFIX] Feature 'pre-anonymization filters in untrusted mode' is not currently supported.

--- a/test/sql/_setup.sql
+++ b/test/sql/_setup.sql
@@ -33,15 +33,11 @@ INSERT INTO test_patients VALUES
 
 CREATE TABLE empty_test_customers (id INTEGER PRIMARY KEY, name TEXT, city TEXT, discount REAL);
 
--- Pre-filtered table to maintain LCF tests which relied on WHERE clause.
-CREATE TABLE london_customers AS (SELECT * FROM test_customers WHERE city = 'London');
-
 -- Config tables (and also check handling of namespaces).
 CALL diffix.mark_personal('public.test_customers', 'id');
 CALL diffix.mark_personal('public.test_purchases', 'cid');
 CALL diffix.mark_personal('public.test_patients', 'id', 'name');
 CALL diffix.mark_personal('public.empty_test_customers', 'id');
-CALL diffix.mark_personal('public.london_customers', 'id');
 CALL diffix.mark_public('public.test_products');
 
 -- There is no CREATE USER IF NOT EXISTS, we need to wrap and silence the output

--- a/test/sql/noiseless.sql
+++ b/test/sql/noiseless.sql
@@ -30,6 +30,8 @@ SELECT COUNT(DISTINCT cid) FROM test_purchases;
 
 SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
 
+SELECT COUNT(*) FROM test_customers WHERE planet = 'Earth';
+
 ----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------
@@ -58,7 +60,7 @@ SELECT city FROM test_customers;
 
 SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
 
-SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;
+SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM test_customers WHERE city = 'London';
 
 ----------------------------------------------------------------
 -- Empty tables

--- a/test/sql/noisy.sql
+++ b/test/sql/noisy.sql
@@ -26,6 +26,8 @@ SELECT COUNT(DISTINCT cid) FROM test_purchases;
 
 SELECT city, COUNT(DISTINCT id) FROM test_customers GROUP BY 1;
 
+SELECT COUNT(*) FROM test_customers WHERE planet = 'Earth';
+
 ----------------------------------------------------------------
 -- Basic queries - expanding constants in target expressions
 ----------------------------------------------------------------
@@ -54,7 +56,7 @@ SELECT city FROM test_customers;
 
 SELECT city FROM test_customers GROUP BY 1 HAVING length(city) <> 4;
 
-SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM london_customers;
+SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM test_customers WHERE city = 'London';
 
 -- LCF doesn't depend on the bucket seed, both queries should have same noisy threshold.
 SELECT diffix.floor_by(age, 30), COUNT(*) FROM test_patients GROUP BY 1;
@@ -65,3 +67,21 @@ SELECT diffix.floor_by(age, 30), diffix.floor_by(age, 106), COUNT(*) FROM test_p
 ----------------------------------------------------------------
 
 SELECT COUNT(*), COUNT(city), COUNT(DISTINCT city) FROM empty_test_customers;
+
+----------------------------------------------------------------
+-- WHERE clauses
+----------------------------------------------------------------
+
+-- Filtering and grouping produce identical results
+(SELECT count(*) FROM test_customers GROUP BY city HAVING city = 'Berlin')
+UNION
+(SELECT count(*) FROM test_customers WHERE city = 'Berlin');
+
+(SELECT count(*) FROM test_customers GROUP BY city, diffix.round_by(discount, 2)
+  HAVING city = 'Berlin' AND diffix.round_by(discount, 2) = 0)
+UNION
+(SELECT count(*) FROM test_customers WHERE city = 'Berlin' AND diffix.round_by(discount, 2) = 0);
+
+(SELECT count(*) FROM test_customers WHERE diffix.round_by(discount, 2) = 0 GROUP BY city HAVING city = 'Berlin')
+UNION
+(SELECT count(*) FROM test_customers WHERE city = 'Berlin' AND diffix.round_by(discount, 2) = 0);

--- a/test/sql/validation.sql
+++ b/test/sql/validation.sql
@@ -88,6 +88,10 @@ SELECT 2 * length(city) FROM test_validation GROUP BY city;
 -- Allow diffix.is_suppress_bin in non-direct access level.
 SELECT city, count(*), diffix.is_suppress_bin(*) from test_validation GROUP BY 1;
 
+-- Allow simple equality filters in WHERE clauses
+SELECT COUNT(*) FROM test_validation WHERE city = 'London';
+SELECT COUNT(*) FROM test_validation WHERE substring(city, 1, 1) = 'L' AND discount = 10.0 AND discount = 20.0;
+
 -- Set operations between anonymizing queries.
 SELECT city FROM test_validation EXCEPT SELECT city FROM test_validation;
 SELECT city FROM test_validation UNION SELECT city FROM test_validation;
@@ -201,8 +205,9 @@ SELECT city, COUNT(price) FROM test_products, test_validation GROUP BY 1;
 
 SELECT city, COUNT(price) FROM test_products CROSS JOIN test_validation GROUP BY 1;
 
--- Get rejected because of WHERE
-SELECT COUNT(*) FROM test_validation WHERE city = 'London';
+-- Get rejected because of invalid WHERE clauses
+SELECT COUNT(*) FROM test_validation WHERE city <> 'London';
+SELECT COUNT(*) FROM test_validation WHERE city = 'London' OR discount = 10;
 
 -- Get rejected because of non-datetime cast to text
 SELECT cast(id AS text) FROM test_validation GROUP BY 1;
@@ -269,3 +274,6 @@ SELECT diffix.floor_by(discount, 5000000000.1) from test_validation;
 SELECT width_bucket(discount, 2, 200, 5) from test_validation;
 SELECT ceil(discount) from test_validation;
 SELECT diffix.ceil_by(discount, 2) from test_validation;
+
+-- Get rejected because of unsupported features
+SELECT count(*) FROM test_validation WHERE discount = 3;


### PR DESCRIPTION
Allow AND-ed equalities in `WHERE` clause in trusted-mode.