### PR TITLE
Support negative summands

### DIFF
--- a/pg_diffix/aggregation/contribution_tracker.h
+++ b/pg_diffix/aggregation/contribution_tracker.h
@@ -25,12 +25,16 @@ typedef contribution_t (*ContributionCombineFunc)(contribution_t x, contribution
 /* Casts x to double. */
 typedef double (*ContributionToDoubleFunc)(contribution_t x);
 
+/* Computes absolute value. */
+typedef contribution_t (*ContributionAbsFunc)(contribution_t x);
+
 typedef struct ContributionDescriptor
 {
   ContributionGreaterFunc contribution_greater;
   ContributionEqualFunc contribution_equal;
   ContributionCombineFunc contribution_combine;
   ContributionToDoubleFunc contribution_to_double;
+  ContributionAbsFunc contribution_abs;
   contribution_t contribution_initial; /* Initial or "zero" value for a contribution */
 } ContributionDescriptor;
 

--- a/src/aggregation/summable.c
+++ b/src/aggregation/summable.c
@@ -27,11 +27,17 @@ static double integer_contribution_to_double(contribution_t x)
   return (double)x.integer;
 }
 
+static contribution_t integer_contribution_abs(contribution_t x)
+{
+  return (contribution_t){.integer = labs(x.integer)};
+}
+
 const ContributionDescriptor integer_descriptor = {
     .contribution_greater = integer_contribution_greater,
     .contribution_equal = integer_contribution_equal,
     .contribution_combine = integer_contribution_combine,
     .contribution_to_double = integer_contribution_to_double,
+    .contribution_abs = integer_contribution_abs,
     .contribution_initial = {.integer = 0},
 };
 static bool real_contribution_greater(contribution_t x, contribution_t y)
@@ -54,11 +60,17 @@ static double real_contribution_to_double(contribution_t x)
   return (double)x.real;
 }
 
+static contribution_t real_contribution_abs(contribution_t x)
+{
+  return (contribution_t){.real = fabs(x.real)};
+}
+
 const ContributionDescriptor real_descriptor = {
     .contribution_greater = real_contribution_greater,
     .contribution_equal = real_contribution_equal,
     .contribution_combine = real_contribution_combine,
     .contribution_to_double = real_contribution_to_double,
+    .contribution_abs = real_contribution_abs,
     .contribution_initial = {.real = 0.0},
 };
 

--- a/test/expected/noiseless.out
+++ b/test/expected/noiseless.out
@@ -6,6 +6,11 @@ SET pg_diffix.outlier_count_min = 1;
 SET pg_diffix.outlier_count_max = 1;
 SET pg_diffix.top_count_min = 3;
 SET pg_diffix.top_count_max = 3;
+-- Additional tables for SUM testing
+CREATE TABLE test_customers_negative AS SELECT id, city, -discount as discount, planet FROM test_customers;
+CREATE TABLE test_customers_mixed AS SELECT id, city, discount - 1.0 as discount, planet FROM test_customers;
+CALL diffix.mark_personal('public.test_customers_negative', 'id');
+CALL diffix.mark_personal('public.test_customers_mixed', 'id');
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'anonymized_trusted';
 ----------------------------------------------------------------
@@ -88,6 +93,18 @@ SELECT city, SUM(discount), diffix.sum_noise(discount) FROM test_customers GROUP
  Rome   | 4.8333335 |         0
  Berlin |         9 |         0
 (3 rows)
+
+SELECT SUM(discount), diffix.sum_noise(discount) FROM test_customers_negative;
+ sum | sum_noise 
+-----+-----------
+ -19 |         0
+(1 row)
+
+SELECT SUM(discount), diffix.sum_noise(discount) FROM test_customers_mixed;
+ sum | sum_noise 
+-----+-----------
+ 2.5 |         0
+(1 row)
 
 -- sum supports numeric type
 SELECT city, SUM(discount::numeric), pg_typeof(SUM(discount::numeric)), diffix.sum_noise(discount::numeric)

--- a/test/expected/validation.out
+++ b/test/expected/validation.out
@@ -294,11 +294,11 @@ SELECT * FROM diffix.show_settings() LIMIT 2;
  pg_diffix.default_access_level | direct  | Access level for unlabeled users.
 (2 rows)
 
-SELECT * FROM diffix.show_labels() WHERE objname LIKE 'public.test_customers%';
- objtype |         objname          |  label   
----------+--------------------------+----------
- table   | public.test_customers    | personal
- column  | public.test_customers.id | aid
+SELECT * FROM diffix.show_labels() WHERE objname LIKE 'public.empty_test_customers%';
+ objtype |            objname             |  label   
+---------+--------------------------------+----------
+ table   | public.empty_test_customers    | personal
+ column  | public.empty_test_customers.id | aid
 (2 rows)
 
 -- Allow prepared statements

--- a/test/sql/noiseless.sql
+++ b/test/sql/noiseless.sql
@@ -8,6 +8,12 @@ SET pg_diffix.outlier_count_max = 1;
 SET pg_diffix.top_count_min = 3;
 SET pg_diffix.top_count_max = 3;
 
+-- Additional tables for SUM testing
+CREATE TABLE test_customers_negative AS SELECT id, city, -discount as discount, planet FROM test_customers;
+CREATE TABLE test_customers_mixed AS SELECT id, city, discount - 1.0 as discount, planet FROM test_customers;
+CALL diffix.mark_personal('public.test_customers_negative', 'id');
+CALL diffix.mark_personal('public.test_customers_mixed', 'id');
+
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'anonymized_trusted';
 
@@ -40,6 +46,9 @@ SELECT SUM(id), diffix.sum_noise(id) FROM test_customers;
 SELECT SUM(discount), diffix.sum_noise(discount) FROM test_customers;
 SELECT city, SUM(id), diffix.sum_noise(id) FROM test_customers GROUP BY 1;
 SELECT city, SUM(discount), diffix.sum_noise(discount) FROM test_customers GROUP BY 1;
+
+SELECT SUM(discount), diffix.sum_noise(discount) FROM test_customers_negative;
+SELECT SUM(discount), diffix.sum_noise(discount) FROM test_customers_mixed;
 
 -- sum supports numeric type
 SELECT city, SUM(discount::numeric), pg_typeof(SUM(discount::numeric)), diffix.sum_noise(discount::numeric)

--- a/test/sql/validation.sql
+++ b/test/sql/validation.sql
@@ -150,7 +150,7 @@ SELECT EXISTS (SELECT FROM Information_Schema.tables WHERE table_schema='public'
 
 -- Settings and labels UDFs work
 SELECT * FROM diffix.show_settings() LIMIT 2;
-SELECT * FROM diffix.show_labels() WHERE objname LIKE 'public.test_customers%';
+SELECT * FROM diffix.show_labels() WHERE objname LIKE 'public.empty_test_customers%';
 
 -- Allow prepared statements
 PREPARE prepared(float) AS SELECT discount, count(*) FROM empty_test_customers WHERE discount = $1 GROUP BY 1;


### PR DESCRIPTION
I somehow managed to miss this altogether in here, probably left for "later" and shifted focus.

This comes in with a bit of an ugly moment when accumulating per-AID-instance results and calculating the `not_enough_aid_values` condition. Since this is the only condition calculated _jointly_ for both legs (positive and negative), it goes against the result accumulator structure we are trying to reuse. I'm still hesitant if this is clean enough to be kept or should we embark on some larger refactoring of the aggregation code.