### PR TITLE
Make datetime bucket seeding independent of `SET DateStyle =`

### DIFF
--- a/src/query/anonymization.c
+++ b/src/query/anonymization.c
@@ -431,22 +431,6 @@ static seed_t prepare_bucket_seeds(Query *query, ParamListInfo bound_params)
   return sql_seed;
 }
 
-static bool is_datetime_type(Oid type)
-{
-  switch (type)
-  {
-  case DATEOID:
-  case TIMEOID:
-  case TIMETZOID:
-  case TIMESTAMPOID:
-  case TIMESTAMPTZOID:
-    return true;
-  default:
-    /* Slower to evaluate, safety net in case new types get added. */
-    return TypeCategory(type) == TYPCATEGORY_DATETIME;
-  }
-}
-
 static hash_t hash_label(Oid type, Datum value, bool is_null)
 {
   if (is_null)
@@ -461,7 +445,7 @@ static hash_t hash_label(Oid type, Datum value, bool is_null)
     return hash_string(value_as_string);
   }
 
-  if (is_datetime_type(type))
+  if (TypeCategory(type) == TYPCATEGORY_DATETIME)
   {
     char value_as_string[MAXDATELEN + 1];
     /* Leveraging `json.h` as a way to get style-stable encoding of various datetime types. */

--- a/test/expected/datetime.out
+++ b/test/expected/datetime.out
@@ -1,0 +1,47 @@
+LOAD 'pg_diffix';
+CREATE TABLE test_datetime (
+  id INTEGER,
+  d DATE,
+  t TIME,
+  ts TIMESTAMP WITHOUT TIME ZONE,
+  tz TIMESTAMP WITH TIME ZONE,
+  i INTERVAL
+);
+INSERT INTO test_datetime VALUES
+  (1, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (2, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (3, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (4, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (5, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (6, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (7, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years');
+CALL diffix.mark_personal('test_datetime', 'id');
+SET ROLE diffix_test;
+SET pg_diffix.session_access_level = 'anonymized_trusted';
+----------------------------------------------------------------
+-- Sanity checks
+----------------------------------------------------------------
+SELECT diffix.access_level();
+    access_level    
+--------------------
+ anonymized_trusted
+(1 row)
+
+----------------------------------------------------------------
+-- Seeding
+----------------------------------------------------------------
+-- Datetime values are seeded the same regardless of global `datestyle` setting
+SET datestyle = 'SQL';
+SELECT ts, count(*) FROM test_datetime GROUP BY 1;
+         ts          | count 
+---------------------+-------
+ 05/14/2012 00:00:00 |     9
+(1 row)
+
+SET datestyle = 'ISO';
+SELECT ts, count(*) FROM test_datetime GROUP BY 1;
+         ts          | count 
+---------------------+-------
+ 2012-05-14 00:00:00 |     9
+(1 row)
+

--- a/test/sql/datetime.sql
+++ b/test/sql/datetime.sql
@@ -1,0 +1,40 @@
+LOAD 'pg_diffix';
+
+CREATE TABLE test_datetime (
+  id INTEGER,
+  d DATE,
+  t TIME,
+  ts TIMESTAMP WITHOUT TIME ZONE,
+  tz TIMESTAMP WITH TIME ZONE,
+  i INTERVAL
+);
+
+INSERT INTO test_datetime VALUES
+  (1, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (2, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (3, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (4, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (5, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (6, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
+  (7, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years');
+
+CALL diffix.mark_personal('test_datetime', 'id');
+
+SET ROLE diffix_test;
+SET pg_diffix.session_access_level = 'anonymized_trusted';
+
+----------------------------------------------------------------
+-- Sanity checks
+----------------------------------------------------------------
+
+SELECT diffix.access_level();
+
+----------------------------------------------------------------
+-- Seeding
+----------------------------------------------------------------
+
+-- Datetime values are seeded the same regardless of global `datestyle` setting
+SET datestyle = 'SQL';
+SELECT ts, count(*) FROM test_datetime GROUP BY 1;
+SET datestyle = 'ISO';
+SELECT ts, count(*) FROM test_datetime GROUP BY 1;


### PR DESCRIPTION
I'm not entirely sure if I like this solution, there is a bunch of alternatives. Let me know what you think

1. I've found what looks like a style-consistent encoder in the `json.h`. We might not like this awkward dependency in the `anonymization.c` file, understandably, but it does exactly what we need. Otherwise I'd just copy-paste most of that `json.h` function and let it rot, which I don't really like.
2. I've also added this `TypeCategory` check, as a fallback in case someone adds a new datetime type to PG, and we don't update the types' list in our `switch`. Of course, this would have to mean that that someone updates the implementation of the `json.h` function. If they don't - seeding of such a new type with throw an error. Here, I think this is marginally better than allowing to manipulate the seeding, so I chose this path, but this is very disputable.
As of today, there is one `TYPCATEGORY_DATETIME` type in the catalog, not supported by `json.h`, but I have not been able to use it in any way (`time_stamp` - spelled with that underscore).