### PR TITLE
Make datetime bucket seeding independent of `SET TIMEZONE =`

### DIFF
--- a/src/query/anonymization.c
+++ b/src/query/anonymization.c
@@ -632,8 +632,9 @@ static hash_t hash_label(Oid type, Datum value, bool is_null)
   if (TypeCategory(type) == TYPCATEGORY_DATETIME)
   {
     char value_as_string[MAXDATELEN + 1];
-    /* Leveraging `json.h` as a way to get style-stable encoding of various datetime types. */
-    JsonEncodeDateTime(value_as_string, value, type, NULL);
+    /* Leveraging `json.h` with UTC to get style-stable encoding of various datetime types. */
+    const int tzp = 0;
+    JsonEncodeDateTime(value_as_string, value, type, &tzp);
     return hash_string(value_as_string);
   }
 

--- a/test/expected/datetime.out
+++ b/test/expected/datetime.out
@@ -45,3 +45,17 @@ SELECT ts, count(*) FROM test_datetime GROUP BY 1;
  2012-05-14 00:00:00 |     9
 (1 row)
 
+SET TIMEZONE TO 'UTC';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+           tz           | count 
+------------------------+-------
+ 2012-05-14 07:00:00+00 |    11
+(1 row)
+
+SET TIMEZONE TO DEFAULT;
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+           tz           | count 
+------------------------+-------
+ 2012-05-14 00:00:00-07 |    11
+(1 row)
+

--- a/test/sql/datetime.sql
+++ b/test/sql/datetime.sql
@@ -38,3 +38,8 @@ SET datestyle = 'SQL';
 SELECT ts, count(*) FROM test_datetime GROUP BY 1;
 SET datestyle = 'ISO';
 SELECT ts, count(*) FROM test_datetime GROUP BY 1;
+
+SET TIMEZONE TO 'UTC';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+SET TIMEZONE TO DEFAULT;
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;


### PR DESCRIPTION
Similar to #440, there's another session setting which impacts seeding.

I've re-read the docs, I think that's all this time :sweat_smile:, if anyone has ideas for any other magical setting which could impact the datetime seeding, please let know.