### PR TITLE
Support date_trunc

### DIFF
--- a/pg_diffix/query/allowed_objects.h
+++ b/pg_diffix/query/allowed_objects.h
@@ -9,6 +9,12 @@
 extern bool is_allowed_function(Oid funcoid);
 
 /*
+ * Returns index of the primary argument of an allowed function, i.e. the one intended to
+ * be the column reference.
+ */
+extern int primary_arg_index(Oid funcoid);
+
+/*
  * Returns whether the OID points to a cast allowed in defining buckets.
  */
 extern bool is_allowed_cast(Oid funcoid);

--- a/src/query/allowed_objects.c
+++ b/src/query/allowed_objects.c
@@ -201,6 +201,7 @@ int primary_arg_index(Oid funcoid)
     if (g_allowed_builtins_extra[i].funcid == funcoid)
       return g_allowed_builtins_extra[i].primary_arg;
   }
+
   FAILWITH("Cannot identify the primary argument position for funcid %u.", funcoid);
 }
 

--- a/src/query/allowed_objects.c
+++ b/src/query/allowed_objects.c
@@ -14,18 +14,49 @@ static const char *const g_allowed_casts[] = {
     "ftod", "dtof",
     "int4_numeric", "float4_numeric", "float8_numeric",
     "numeric_float4", "numeric_float8",
+    "date_timestamptz",
     /**/
 };
 
-static const char *const g_allowed_builtins[] = {
+typedef struct FunctionByName
+{
+  const char *name;
+  int primary_arg;
+} FunctionByName;
+
+typedef struct FunctionByOid
+{
+  Oid funcid;
+  int primary_arg;
+} FunctionByOid;
+
+static const FunctionByName g_allowed_builtins[] = {
     /* rounding casts */
-    "ftoi2", "ftoi4", "ftoi8", "dtoi2", "dtoi4", "dtoi8", "numeric_int4",
+    (FunctionByName){.name = "ftoi2", .primary_arg = 0},
+    (FunctionByName){.name = "ftoi4", .primary_arg = 0},
+    (FunctionByName){.name = "ftoi8", .primary_arg = 0},
+    (FunctionByName){.name = "dtoi2", .primary_arg = 0},
+    (FunctionByName){.name = "dtoi4", .primary_arg = 0},
+    (FunctionByName){.name = "dtoi8", .primary_arg = 0},
+    (FunctionByName){.name = "numeric_int4", .primary_arg = 0},
     /* substring */
-    "text_substr", "text_substr_no_len", "bytea_substr", "bytea_substr_no_len",
+    (FunctionByName){.name = "text_substr", .primary_arg = 0},
+    (FunctionByName){.name = "text_substr_no_len", .primary_arg = 0},
+    (FunctionByName){.name = "bytea_substr", .primary_arg = 0},
+    (FunctionByName){.name = "bytea_substr_no_len", .primary_arg = 0},
     /* numeric generalization */
-    "dround", "numeric_round", "dceil", "numeric_ceil", "dfloor", "numeric_floor",
+    (FunctionByName){.name = "dround", .primary_arg = 0},
+    (FunctionByName){.name = "numeric_round", .primary_arg = 0},
+    (FunctionByName){.name = "dceil", .primary_arg = 0},
+    (FunctionByName){.name = "numeric_ceil", .primary_arg = 0},
+    (FunctionByName){.name = "dfloor", .primary_arg = 0},
+    (FunctionByName){.name = "numeric_floor", .primary_arg = 0},
     /* width_bucket */
-    "width_bucket_float8", "width_bucket_numeric",
+    (FunctionByName){.name = "width_bucket_float8", .primary_arg = 0},
+    (FunctionByName){.name = "width_bucket_numeric", .primary_arg = 0},
+    /* date_trunc */
+    (FunctionByName){.name = "timestamptz_trunc", .primary_arg = 1},
+    (FunctionByName){.name = "timestamp_trunc", .primary_arg = 1},
     /**/
 };
 
@@ -42,7 +73,7 @@ static const char *const g_implicit_range_builtins_untrusted[] = {
 
 /* Some allowed functions don't appear in the builtins catalog, so we must allow them manually by OID. */
 #define F_NUMERIC_ROUND_INT 1708
-static const Oid g_allowed_builtins_extra[] = {F_NUMERIC_ROUND_INT};
+static const FunctionByOid g_allowed_builtins_extra[] = {(FunctionByOid){.funcid = F_NUMERIC_ROUND_INT, .primary_arg = 0}};
 
 typedef struct AllowedCols
 {
@@ -116,6 +147,21 @@ static const FmgrBuiltin *fmgr_isbuiltin(Oid id)
   return &fmgr_builtins[index];
 }
 
+static bool is_func_member_of(Oid funcoid, const FunctionByName func_array[], int length)
+{
+  const FmgrBuiltin *fmgr_builtin = fmgr_isbuiltin(funcoid);
+  if (fmgr_builtin != NULL)
+  {
+    for (int i = 0; i < length; i++)
+    {
+      if (strcmp(func_array[i].name, fmgr_builtin->funcName) == 0)
+        return true;
+    }
+  }
+
+  return false;
+}
+
 static bool is_funcname_member_of(Oid funcoid, const char *const name_array[], int length)
 {
   const FmgrBuiltin *fmgr_builtin = fmgr_isbuiltin(funcoid);
@@ -129,6 +175,33 @@ static bool is_funcname_member_of(Oid funcoid, const char *const name_array[], i
   }
 
   return false;
+}
+
+int primary_arg_index(Oid funcoid)
+{
+  for (int i = 0; i < ARRAY_LENGTH(g_implicit_range_udfs); i++)
+  {
+    /* We ensured that our UDFs have the primary arg first. */
+    if (*g_implicit_range_udfs[i] == funcoid)
+      return 0;
+  }
+
+  const FmgrBuiltin *fmgr_builtin = fmgr_isbuiltin(funcoid);
+  if (fmgr_builtin != NULL)
+  {
+    for (int i = 0; i < ARRAY_LENGTH(g_allowed_builtins); i++)
+    {
+      if (strcmp(g_allowed_builtins[i].name, fmgr_builtin->funcName) == 0)
+        return g_allowed_builtins[i].primary_arg;
+    }
+  }
+
+  for (int i = 0; i < ARRAY_LENGTH(g_allowed_builtins_extra); i++)
+  {
+    if (g_allowed_builtins_extra[i].funcid == funcoid)
+      return g_allowed_builtins_extra[i].primary_arg;
+  }
+  FAILWITH("Cannot identify the primary argument position for funcid %u.", funcoid);
 }
 
 bool is_allowed_cast(Oid funcoid)
@@ -154,12 +227,12 @@ bool is_allowed_function(Oid funcoid)
       return true;
   }
 
-  if (is_funcname_member_of(funcoid, g_allowed_builtins, ARRAY_LENGTH(g_allowed_builtins)))
+  if (is_func_member_of(funcoid, g_allowed_builtins, ARRAY_LENGTH(g_allowed_builtins)))
     return true;
 
   for (int i = 0; i < ARRAY_LENGTH(g_allowed_builtins_extra); i++)
   {
-    if (g_allowed_builtins_extra[i] == funcoid)
+    if (g_allowed_builtins_extra[i].funcid == funcoid)
       return true;
   }
 

--- a/src/query/validation.c
+++ b/src/query/validation.c
@@ -237,11 +237,14 @@ static void verify_bucket_expression(Node *node)
 
     Assert(list_length(func_expr->args) > 0); /* All allowed functions require at least one argument. */
 
-    if (!IsA(unwrap_cast(linitial(func_expr->args)), Var))
+    int primary_arg = primary_arg_index(func_expr->funcid);
+    if (!IsA(unwrap_cast(list_nth(func_expr->args, primary_arg)), Var))
       FAILWITH_LOCATION(func_expr->location, "Primary argument for a generalization function has to be a simple column reference.");
 
-    for (int i = 1; i < list_length(func_expr->args); i++)
+    for (int i = 0; i < list_length(func_expr->args); i++)
     {
+      if (i == primary_arg)
+        continue;
       Node *arg = unwrap_cast((Node *)list_nth(func_expr->args, i));
       if (!is_stable_expression(arg))
         FAILWITH_LOCATION(exprLocation(arg), "Non-primary arguments for a generalization function have to be simple constants.");

--- a/test/expected/datetime.out
+++ b/test/expected/datetime.out
@@ -16,6 +16,7 @@ INSERT INTO test_datetime VALUES
   (6, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years'),
   (7, '2012-05-14', '14:59', '2012-05-14', '2012-05-14', '1 years');
 CALL diffix.mark_personal('test_datetime', 'id');
+GRANT ALL PRIVILEGES ON TABLE test_datetime TO diffix_test; 
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'anonymized_trusted';
 ----------------------------------------------------------------
@@ -30,7 +31,7 @@ SELECT diffix.access_level();
 ----------------------------------------------------------------
 -- Seeding
 ----------------------------------------------------------------
--- Datetime values are seeded the same regardless of global `datestyle` setting
+-- Datetime values are seeded in UTC the same regardless of global `datestyle` setting
 SET datestyle = 'SQL';
 SELECT ts, count(*) FROM test_datetime GROUP BY 1;
          ts          | count 
@@ -43,5 +44,37 @@ SELECT ts, count(*) FROM test_datetime GROUP BY 1;
          ts          | count 
 ---------------------+-------
  2012-05-14 00:00:00 |     9
+(1 row)
+
+SET TIMEZONE TO 'EST';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+           tz           | count 
+------------------------+-------
+ 2012-05-14 02:00:00-05 |    11
+(1 row)
+
+SET TIMEZONE TO 'UTC';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+           tz           | count 
+------------------------+-------
+ 2012-05-14 07:00:00+00 |    11
+(1 row)
+
+SET pg_diffix.session_access_level = 'direct';
+UPDATE test_datetime SET tz = '2012-05-14T07:00+00:00' WHERE true;
+SET pg_diffix.session_access_level = 'anonymized_trusted';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+           tz           | count 
+------------------------+-------
+ 2012-05-14 07:00:00+00 |    11
+(1 row)
+
+SET pg_diffix.session_access_level = 'direct';
+UPDATE test_datetime SET tz = '2012-05-14T08:00+01:00' WHERE true;
+SET pg_diffix.session_access_level = 'anonymized_trusted';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+           tz           | count 
+------------------------+-------
+ 2012-05-14 07:00:00+00 |    11
 (1 row)
 

--- a/test/expected/validation.out
+++ b/test/expected/validation.out
@@ -6,7 +6,8 @@ CREATE TABLE test_validation (
   discount REAL,
   birthday DATE,
   lunchtime TIME,
-  last_seen TIMESTAMP
+  last_seen TIMESTAMP,
+  last_seen_tz TIMESTAMP WITH TIME ZONE
 );
 CALL diffix.mark_personal('test_validation', 'id');
 CALL diffix.mark_not_filterable('test_validation', 'birthday');
@@ -116,12 +117,23 @@ GROUP BY 1, 2;
 
 SELECT
   substring(cast(last_seen AS text), 1, 3),
+  substring(cast(last_seen_tz AS text), 1, 3),
   substring(cast(birthday AS text), 2, 3),
   substring(cast(lunchtime AS varchar), 1, 4)
 FROM test_validation
+GROUP BY 1, 2, 3, 4;
+ substring | substring | substring | substring 
+-----------+-----------+-----------+-----------
+(0 rows)
+
+SELECT
+  date_trunc('year', last_seen),
+  date_trunc('year', last_seen_tz),
+  date_trunc('year', birthday)
+FROM test_validation
 GROUP BY 1, 2, 3;
- substring | substring | substring 
------------+-----------+-----------
+ date_trunc | date_trunc | date_trunc 
+------------+------------+------------
 (0 rows)
 
 -- Allow all functions post-anonymization.
@@ -427,6 +439,16 @@ SELECT COUNT(*) FROM test_validation GROUP BY substr('aaaa', 1, 2);
 ERROR:  [PG_DIFFIX] Primary argument for a generalization function has to be a simple column reference.
 LINE 1: SELECT COUNT(*) FROM test_validation GROUP BY substr('aaaa',...
                                                       ^
+-- Get rejected because of lack of interval support
+SELECT date_trunc('year', lunchtime) FROM test_validation GROUP BY 1;
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
+LINE 1: SELECT date_trunc('year', lunchtime) FROM test_validation GR...
+               ^
+-- Get rejected because of averaging opportunity
+SELECT  date_trunc('year', last_seen_tz, 'EST') FROM test_validation GROUP BY 1;
+ERROR:  [PG_DIFFIX] Unsupported function used for generalization.
+LINE 1: SELECT  date_trunc('year', last_seen_tz, 'EST') FROM test_va...
+                ^
 -- Get rejected because expression node type is unsupported.
 SELECT COALESCE(discount, 20) FROM test_validation;
 ERROR:  [PG_DIFFIX] Unsupported generalization expression.

--- a/test/sql/datetime.sql
+++ b/test/sql/datetime.sql
@@ -20,6 +20,7 @@ INSERT INTO test_datetime VALUES
 
 CALL diffix.mark_personal('test_datetime', 'id');
 
+GRANT ALL PRIVILEGES ON TABLE test_datetime TO diffix_test; 
 SET ROLE diffix_test;
 SET pg_diffix.session_access_level = 'anonymized_trusted';
 
@@ -33,8 +34,22 @@ SELECT diffix.access_level();
 -- Seeding
 ----------------------------------------------------------------
 
--- Datetime values are seeded the same regardless of global `datestyle` setting
+-- Datetime values are seeded in UTC the same regardless of global `datestyle` setting
 SET datestyle = 'SQL';
 SELECT ts, count(*) FROM test_datetime GROUP BY 1;
 SET datestyle = 'ISO';
 SELECT ts, count(*) FROM test_datetime GROUP BY 1;
+
+SET TIMEZONE TO 'EST';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+SET TIMEZONE TO 'UTC';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+
+SET pg_diffix.session_access_level = 'direct';
+UPDATE test_datetime SET tz = '2012-05-14T07:00+00:00' WHERE true;
+SET pg_diffix.session_access_level = 'anonymized_trusted';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;
+SET pg_diffix.session_access_level = 'direct';
+UPDATE test_datetime SET tz = '2012-05-14T08:00+01:00' WHERE true;
+SET pg_diffix.session_access_level = 'anonymized_trusted';
+SELECT tz, count(*) FROM test_datetime GROUP BY 1;

--- a/test/sql/validation.sql
+++ b/test/sql/validation.sql
@@ -7,7 +7,8 @@ CREATE TABLE test_validation (
   discount REAL,
   birthday DATE,
   lunchtime TIME,
-  last_seen TIMESTAMP
+  last_seen TIMESTAMP,
+  last_seen_tz TIMESTAMP WITH TIME ZONE
 );
 
 CALL diffix.mark_personal('test_validation', 'id');
@@ -86,8 +87,16 @@ GROUP BY 1, 2;
 
 SELECT
   substring(cast(last_seen AS text), 1, 3),
+  substring(cast(last_seen_tz AS text), 1, 3),
   substring(cast(birthday AS text), 2, 3),
   substring(cast(lunchtime AS varchar), 1, 4)
+FROM test_validation
+GROUP BY 1, 2, 3, 4;
+
+SELECT
+  date_trunc('year', last_seen),
+  date_trunc('year', last_seen_tz),
+  date_trunc('year', birthday)
 FROM test_validation
 GROUP BY 1, 2, 3;
 
@@ -210,6 +219,12 @@ SELECT COUNT(*) FROM test_validation GROUP BY round(floor(id));
 SELECT COUNT(*) FROM test_validation GROUP BY floor(cast(discount AS integer));
 SELECT COUNT(*) FROM test_validation GROUP BY substr(city, 1, id);
 SELECT COUNT(*) FROM test_validation GROUP BY substr('aaaa', 1, 2);
+
+-- Get rejected because of lack of interval support
+SELECT date_trunc('year', lunchtime) FROM test_validation GROUP BY 1;
+
+-- Get rejected because of averaging opportunity
+SELECT  date_trunc('year', last_seen_tz, 'EST') FROM test_validation GROUP BY 1;
 
 -- Get rejected because expression node type is unsupported.
 SELECT COALESCE(discount, 20) FROM test_validation;


### PR DESCRIPTION
A lot of rough edges on this one, so opening as draft.

I'm not happy with entire implementation of `primary_arg`, but the best alternative I see is to add a rich `function_infos` dictionary in `oid_cache`, populate it during startup/first use and look up things like `is_cast` and `primary_arg` by OID there. However, previously we rejected the "populate on startup" part so I didn't venture there yet.

Second point: I abstracted away the part to get seed material by type, but now this involves a lot of `pallocs`. I checked with the `stress.sql` test and query to `taxi` and the timing is the same.

Lastly, I didn't go down the normalization path, as I'm not sure it's worth the extra code and abstractions at this point.