### PR TITLE
Fix the META.json license entry

### DIFF
--- a/META.json
+++ b/META.json
@@ -4,9 +4,7 @@
   "description": "Diffix is a bundled set of mechanisms for anonymizing structured data. Open Diffix is a project to make Diffix anonymization free and open. More details at open-diffix.org.",
   "version": "1.2.0",
   "maintainer": "Open Diffix <hello@open-diffix.org>",
-  "license": {
-    "restricted": "https://github.com/diffix/pg_diffix/blob/master/LICENSE.md"
-  },
+  "license": "mit",
   "release_status": "stable",
   "provides": {
     "pg_diffix": {


### PR DESCRIPTION
The link was broken and the license appears to be the MIT license, so switch to that.

Looks like all existing releases on PGXN are using the [Business Source License 1.1](https://spdx.org/licenses/BUSL-1.1.html), so when it switches to using SPDX licenses it will reindex older versions with that license.